### PR TITLE
feat: add dark mode and bilingual UI

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1,5 +1,11 @@
-﻿@tailwind base;
-@tailwind components;
+:root {
+  color-scheme: light dark;
+}
+
+body {
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  @apply bg-slate-50 text-slate-900 transition-colors duration-300;
+  @apply dark:bg-slate-950 dark:text-slate-100;
 @tailwind utilities;
 
 :root {

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,5 +1,11 @@
-﻿import "./globals.css";
-import type { Metadata } from "next";
+    <html lang="fr">
+      <body className="min-h-screen bg-slate-50 text-slate-900 antialiased transition-colors duration-300 dark:bg-slate-950 dark:text-slate-100">
+        {children}
+      </body>
+    </html>
+  );
+}
+
 import type { ReactNode } from "react";
 
 export const metadata: Metadata = {

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,11 +1,9 @@
 "use client";
 
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import * as XLSX from "xlsx";
 
 const truthyValues = new Set(["true", "1", "yes", "oui", "y", "x"]);
-
-const DEFAULT_STATUS = "Aucun fichier importé. Déposez un template Excel ou créez vos règles manuellement.";
 
 type AllowedType = "list" | "instruction";
 
@@ -35,6 +33,188 @@ type RulePayload = {
   pattern: string;
   customRule: string;
 };
+
+type Language = "fr" | "en";
+type Theme = "light" | "dark";
+
+type TranslationReplacements = Record<string, string | number>;
+
+const translations = {
+  fr: {
+    appTitle: "Validation DMF",
+    appDescription:
+      "Déposez votre template Excel pour visualiser les règles, personnalisez-les dans l'application puis lancez la validation Python.",
+    uploadCallToAction: "Déposer un fichier Excel",
+    uploadDetails: "Feuilles attendues: Template & ValidationRules",
+    detectedRulesTitle: "Règles détectées",
+    detectedRulesDescription:
+      "Interprétation lisible de la feuille ValidationRules et édition directement dans l'interface.",
+    rulesBadge: "{count} règle{plural}",
+    addRule: "Ajouter une règle",
+    usageTipsTitle: "Astuce d'utilisation",
+    usageTipsBullet1: "Activez ou désactivez les contrôles comme dans la feuille Excel.",
+    usageTipsBullet2: "Basculer sur « Instruction » permet de référencer une feuille annexe avec SHEET=NomFeuille.",
+    usageTipsBullet3: "Ajoutez autant de valeurs autorisées que nécessaire en saisissant une valeur par ligne.",
+    noRulesMessage:
+      "Aucune règle à afficher pour l'instant. Importez un fichier ou créez votre première règle pour démarrer la configuration.",
+    createFirstRule: "Créer une première règle",
+    fieldLabel: "Champ",
+    fieldPlaceholder: "Nom du champ dans la feuille Template",
+    fieldRequired: "Le nom du champ est requis pour lancer la validation.",
+    removeRule: "Supprimer la règle",
+    toggleChecked: "Activer le contrôle",
+    toggleRequired: "Champ requis",
+    minLengthLabel: "Taille min",
+    maxLengthLabel: "Taille max",
+    optionalPlaceholder: "Optionnel",
+    patternLabel: "Pattern (RegExp)",
+    patternPlaceholder: "Ex: ^[0-9]{5}$",
+    customRuleLabel: "Règle personnalisée",
+    customRulePlaceholder: "Nom de la fonction Python personnalisée",
+    allowedSourceLabel: "Source des valeurs autorisées",
+    allowedSourceList: "Liste de valeurs",
+    allowedSourceInstruction: "Instruction (VALUE=, SHEET=, etc.)",
+    allowedValuesLabel: "Valeurs autorisées",
+    allowedValuesPlaceholder: "Saisissez une valeur par ligne",
+    allowedValuesHelper: "Ces valeurs seront converties en instruction VALUE= lors de la validation.",
+    allowedInstructionLabel: "Instruction AllowedValues",
+    allowedInstructionPlaceholder: "Ex: SHEET=AnnuaireCodes ou VALUE=A;B;C",
+    allowedInstructionHelper:
+      "Utilisez SHEET=NomFeuille pour charger une feuille annexe ou toute instruction personnalisée.",
+    statusDefault:
+      "Aucun fichier importé. Déposez un template Excel ou créez vos règles manuellement.",
+    statusEdited: "Règles personnalisées en attente de validation.",
+    statusNewRule: "Nouvelle règle ajoutée. Complétez-la avant la validation.",
+    statusRulesUpdated: "Règles mises à jour.",
+    statusAnalyzing: "Analyse de {file}…",
+    statusAnalyzed: "Fichier analysé. Modifiez les règles si nécessaire avant validation.",
+    statusTemplate:
+      'Aucune règle trouvée. Les colonnes de la feuille "Template" ont été importées comme base par défaut.',
+    statusNoRules:
+      'Aucune règle trouvée et aucun en-tête détecté dans la feuille "Template". Ajoutez vos règles manuellement.',
+    statusReadError: "Erreur lors de la lecture du fichier. Vérifiez le format Excel.",
+    statusValidating: "Validation en cours…",
+    statusValidationError: "Erreur validation: {message}",
+    statusValidationFailed: "La validation a échoué.",
+    statusValidationComplete: "Validation terminée.",
+    statusNetworkError: "Erreur réseau: impossible de contacter le service de validation.",
+    deleteFile: "Supprimer le fichier",
+    launchValidation: "Lancer la validation Python",
+    validating: "Validation…",
+    downloadReport: "Télécharger le rapport",
+    languageLabel: "Langue",
+    themeLabel: "Thème",
+    lightTheme: "Clair",
+    darkTheme: "Sombre",
+  },
+  en: {
+    appTitle: "DMF validation",
+    appDescription:
+      "Drop your Excel template to inspect the rules, tweak them in the app, then run the Python validation.",
+    uploadCallToAction: "Upload an Excel file",
+    uploadDetails: "Expected sheets: Template & ValidationRules",
+    detectedRulesTitle: "Detected rules",
+    detectedRulesDescription:
+      "Human-friendly interpretation of the ValidationRules sheet with inline editing capabilities.",
+    rulesBadge: "{count} rule{plural}",
+    addRule: "Add a rule",
+    usageTipsTitle: "Usage tip",
+    usageTipsBullet1: "Enable or disable checks just like in the Excel sheet.",
+    usageTipsBullet2: "Switching to “Instruction” lets you reference an extra sheet with SHEET=NomFeuille.",
+    usageTipsBullet3: "Add as many allowed values as needed by entering one per line.",
+    noRulesMessage:
+      "No rule to display yet. Import a file or create your first rule to start configuring.",
+    createFirstRule: "Create a first rule",
+    fieldLabel: "Field",
+    fieldPlaceholder: "Field name in the Template sheet",
+    fieldRequired: "The field name is required to start the validation.",
+    removeRule: "Remove the rule",
+    toggleChecked: "Enable validation",
+    toggleRequired: "Required field",
+    minLengthLabel: "Min length",
+    maxLengthLabel: "Max length",
+    optionalPlaceholder: "Optional",
+    patternLabel: "Pattern (RegExp)",
+    patternPlaceholder: "e.g. ^[0-9]{5}$",
+    customRuleLabel: "Custom rule",
+    customRulePlaceholder: "Name of the custom Python function",
+    allowedSourceLabel: "Source of allowed values",
+    allowedSourceList: "List of values",
+    allowedSourceInstruction: "Instruction (VALUE=, SHEET=, etc.)",
+    allowedValuesLabel: "Allowed values",
+    allowedValuesPlaceholder: "Enter one value per line",
+    allowedValuesHelper: "These values will be converted into a VALUE= instruction during validation.",
+    allowedInstructionLabel: "AllowedValues instruction",
+    allowedInstructionPlaceholder: "e.g. SHEET=ReferenceCodes or VALUE=A;B;C",
+    allowedInstructionHelper:
+      "Use SHEET=SheetName to load an extra sheet or any custom instruction.",
+    statusDefault:
+      "No file imported yet. Drop an Excel template or create your rules manually.",
+    statusEdited: "Custom rules pending validation.",
+    statusNewRule: "New rule added. Complete it before running the validation.",
+    statusRulesUpdated: "Rules updated.",
+    statusAnalyzing: "Analysing {file}…",
+    statusAnalyzed: "File analysed. Adjust the rules if needed before running the validation.",
+    statusTemplate:
+      'No rule found. Columns from the "Template" sheet were imported as a default baseline.',
+    statusNoRules:
+      'No rule found and no header detected in the "Template" sheet. Add your rules manually.',
+    statusReadError: "Error while reading the file. Check the Excel format.",
+    statusValidating: "Validation in progress…",
+    statusValidationError: "Validation error: {message}",
+    statusValidationFailed: "Validation failed.",
+    statusValidationComplete: "Validation completed.",
+    statusNetworkError: "Network error: unable to contact the validation service.",
+    deleteFile: "Remove file",
+    launchValidation: "Launch Python validation",
+    validating: "Validating…",
+    downloadReport: "Download report",
+    languageLabel: "Language",
+    themeLabel: "Theme",
+    lightTheme: "Light",
+    darkTheme: "Dark",
+  },
+} as const;
+
+type TranslationKey = keyof (typeof translations)["fr"];
+type StatusKey =
+  | "statusDefault"
+  | "statusEdited"
+  | "statusNewRule"
+  | "statusRulesUpdated"
+  | "statusAnalyzing"
+  | "statusAnalyzed"
+  | "statusTemplate"
+  | "statusNoRules"
+  | "statusReadError"
+  | "statusValidating"
+  | "statusValidationError"
+  | "statusValidationFailed"
+  | "statusValidationComplete"
+  | "statusNetworkError";
+
+type StatusMessage =
+  | { kind: "key"; key: StatusKey; replacements?: TranslationReplacements }
+  | { kind: "custom"; text: string };
+
+function translate(language: Language, key: TranslationKey, replacements?: TranslationReplacements): string {
+  const template = translations[language][key];
+  if (!template) {
+    return key;
+  }
+
+  if (!replacements) {
+    return template;
+  }
+
+  return Object.entries(replacements).reduce((acc, [token, value]) => {
+    return acc.split(`{${token}}`).join(String(value));
+  }, template);
+}
+
+function createStatus(key: StatusKey, replacements?: TranslationReplacements): StatusMessage {
+  return { kind: "key", key, replacements };
+}
 
 function createId(): string {
   if (typeof globalThis.crypto?.randomUUID === "function") {
@@ -185,9 +365,11 @@ function extractTemplateFields(sheet?: XLSX.WorkSheet): string[] {
 }
 
 export default function HomePage() {
+  const [language, setLanguage] = useState<Language>("fr");
+  const [theme, setTheme] = useState<Theme>("light");
   const [rules, setRules] = useState<RuleRow[]>([]);
   const [file, setFile] = useState<File | null>(null);
-  const [status, setStatus] = useState<string>(DEFAULT_STATUS);
+  const [statusMessage, setStatusMessage] = useState<StatusMessage>(createStatus("statusDefault"));
   const [reportUrl, setReportUrl] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
   const [rulesEdited, setRulesEdited] = useState<boolean>(false);
@@ -195,14 +377,69 @@ export default function HomePage() {
 
   const hasMissingField = useMemo(() => rules.some((rule) => !rule.field.trim()), [rules]);
 
-  function markRulesEdited(message?: string) {
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+    const storedLanguage = window.localStorage.getItem("dmf-language");
+    if (storedLanguage === "fr" || storedLanguage === "en") {
+      setLanguage(storedLanguage);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+    const storedTheme = window.localStorage.getItem("dmf-theme");
+    if (storedTheme === "light" || storedTheme === "dark") {
+      setTheme(storedTheme);
+      return;
+    }
+    const prefersDark = window.matchMedia?.("(prefers-color-scheme: dark)")?.matches ?? false;
+    setTheme(prefersDark ? "dark" : "light");
+  }, []);
+
+  useEffect(() => {
+    if (typeof document === "undefined") {
+      return;
+    }
+    document.documentElement.classList.toggle("dark", theme === "dark");
+    document.documentElement.style.colorScheme = theme;
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem("dmf-theme", theme);
+    }
+  }, [theme]);
+
+  useEffect(() => {
+    if (typeof document === "undefined") {
+      return;
+    }
+    document.documentElement.lang = language;
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem("dmf-language", language);
+    }
+  }, [language]);
+
+  const t = useMemo(
+    () =>
+      (key: TranslationKey, replacements?: TranslationReplacements) =>
+        translate(language, key, replacements),
+    [language],
+  );
+
+  const statusText = statusMessage.kind === "key"
+    ? t(statusMessage.key, statusMessage.replacements)
+    : statusMessage.text;
+
+  function markRulesEdited(message?: StatusMessage) {
     setRulesEdited(true);
     if (!isSubmitting) {
-      setStatus(message ?? "Règles personnalisées en attente de validation.");
+      setStatusMessage(message ?? createStatus("statusEdited"));
     }
   }
 
-  function resetSelection(message?: string) {
+  function resetSelection(message?: StatusMessage) {
     if (fileInputRef.current) {
       fileInputRef.current.value = "";
     }
@@ -210,7 +447,7 @@ export default function HomePage() {
     setRules([]);
     setRulesEdited(false);
     setReportUrl(null);
-    setStatus(message ?? DEFAULT_STATUS);
+    setStatusMessage(message ?? createStatus("statusDefault"));
   }
 
   function updateRule(id: string, updates: Partial<RuleRow>) {
@@ -239,12 +476,12 @@ export default function HomePage() {
 
   function addRule() {
     setRules((prev) => [...prev, createEmptyRule()]);
-    markRulesEdited("Nouvelle règle ajoutée. Complétez-la avant la validation.");
+    markRulesEdited(createStatus("statusNewRule"));
   }
 
   function removeRule(id: string) {
     setRules((prev) => prev.filter((rule) => rule.id !== id));
-    markRulesEdited("Règles mises à jour.");
+    markRulesEdited(createStatus("statusRulesUpdated"));
   }
 
   async function handleFileChange(event: React.ChangeEvent<HTMLInputElement>) {
@@ -259,7 +496,7 @@ export default function HomePage() {
     setRules([]);
     setRulesEdited(false);
     setFile(selected);
-    setStatus(`Analyse de ${selected.name}…`);
+    setStatusMessage(createStatus("statusAnalyzing", { file: selected.name }));
 
     try {
       const data = await selected.arrayBuffer();
@@ -279,7 +516,7 @@ export default function HomePage() {
       if (mappedRules.length > 0) {
         setRules(mappedRules);
         setRulesEdited(false);
-        setStatus("Fichier analysé. Modifiez les règles si nécessaire avant validation.");
+        setStatusMessage(createStatus("statusAnalyzed"));
         return;
       }
 
@@ -288,27 +525,23 @@ export default function HomePage() {
         const generatedRules = templateFields.map((field) => createRuleFromField(field));
         setRules(generatedRules);
         setRulesEdited(true);
-        setStatus(
-          'Aucune règle trouvée. Les colonnes de la feuille "Template" ont été importées comme base par défaut.',
-        );
+        setStatusMessage(createStatus("statusTemplate"));
         return;
       }
 
       setRules([]);
       setRulesEdited(false);
-      setStatus(
-        'Aucune règle trouvée et aucun en-tête détecté dans la feuille "Template". Ajoutez vos règles manuellement.',
-      );
+      setStatusMessage(createStatus("statusNoRules"));
     } catch (error) {
       console.error(error);
-      setStatus("Erreur lors de la lecture du fichier. Vérifiez le format Excel.");
+      setStatusMessage(createStatus("statusReadError"));
     }
   }
 
   async function launchValidation() {
     if (!file) return;
     setIsSubmitting(true);
-    setStatus("Validation en cours…");
+    setStatusMessage(createStatus("statusValidating"));
     setReportUrl(null);
 
     try {
@@ -327,7 +560,7 @@ export default function HomePage() {
 
       if (!response.ok) {
         const message = await response.text();
-        setStatus(`Erreur validation: ${message}`);
+        setStatusMessage(createStatus("statusValidationError", { message }));
         return;
       }
 
@@ -338,81 +571,149 @@ export default function HomePage() {
       } = await response.json();
 
       if (!payload.success) {
-        setStatus(payload.message ?? "La validation a échoué.");
+        setStatusMessage(
+          payload.message ? { kind: "custom", text: payload.message } : createStatus("statusValidationFailed"),
+        );
         return;
       }
 
-      setStatus(payload.message ?? "Validation terminée.");
+      setStatusMessage(
+        payload.message ? { kind: "custom", text: payload.message } : createStatus("statusValidationComplete"),
+      );
       if (payload.downloadUrl) {
         setReportUrl(payload.downloadUrl);
       }
     } catch (error) {
       console.error(error);
-      setStatus("Erreur réseau: impossible de contacter le service de validation.");
+      setStatusMessage(createStatus("statusNetworkError"));
     } finally {
       setIsSubmitting(false);
     }
   }
 
+  const ruleBadge = t("rulesBadge", {
+    count: String(rules.length),
+    plural: rules.length > 1 ? "s" : "",
+  });
+
+  const languageOptions: { code: Language; icon: string; label: string }[] = [
+    { code: "fr", icon: "🇫🇷", label: "Français" },
+    { code: "en", icon: "🇬🇧", label: "English" },
+  ];
+
+  const themeOptions: { value: Theme; icon: string; labelKey: "lightTheme" | "darkTheme" }[] = [
+    { value: "light", icon: "☀️", labelKey: "lightTheme" },
+    { value: "dark", icon: "🌙", labelKey: "darkTheme" },
+  ];
+
   return (
-    <main className="min-h-screen bg-slate-50 p-6 md:p-10">
+    <main className="min-h-screen bg-slate-50 p-6 transition-colors duration-300 dark:bg-slate-900 md:p-10">
       <section className="mx-auto flex max-w-5xl flex-col gap-8">
-        <header className="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-100">
-          <h1 className="text-2xl font-semibold text-slate-900">Validation DMF</h1>
-          <p className="mt-2 text-sm text-slate-600">
-            Déposez votre template Excel pour visualiser les règles, personnalisez-les dans l'application puis lancez la
-            validation Python.
-          </p>
-          <label className="mt-6 flex cursor-pointer flex-col items-center gap-2 rounded-xl border-2 border-dashed border-slate-300 p-6 text-center transition hover:border-indigo-400">
-            <span className="text-base font-medium text-slate-700">Déposer un fichier Excel</span>
-            <span className="text-sm text-slate-500">Feuilles attendues: Template &amp; ValidationRules</span>
+        <div className="flex flex-col items-stretch gap-3 self-end sm:flex-row sm:items-center">
+          <div className="flex items-center gap-2">
+            <span className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+              {t("languageLabel")}
+            </span>
+            <div className="flex rounded-full border border-slate-200 bg-white p-1 shadow-sm dark:border-slate-700 dark:bg-slate-900">
+              {languageOptions.map((option) => {
+                const isActive = option.code === language;
+                return (
+                  <button
+                    key={option.code}
+                    type="button"
+                    onClick={() => setLanguage(option.code)}
+                    aria-pressed={isActive}
+                    aria-label={option.label}
+                    className={`flex items-center gap-1 rounded-full px-3 py-1 text-xs font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 ${
+                      isActive
+                        ? "bg-indigo-600 text-white shadow-sm"
+                        : "text-slate-600 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800"
+                    }`}
+                  >
+                    <span aria-hidden="true">{option.icon}</span>
+                    <span>{option.code.toUpperCase()}</span>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+              {t("themeLabel")}
+            </span>
+            <div className="flex rounded-full border border-slate-200 bg-white p-1 shadow-sm dark:border-slate-700 dark:bg-slate-900">
+              {themeOptions.map((option) => {
+                const isActive = option.value === theme;
+                return (
+                  <button
+                    key={option.value}
+                    type="button"
+                    onClick={() => setTheme(option.value)}
+                    aria-pressed={isActive}
+                    aria-label={t(option.labelKey)}
+                    className={`flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 ${
+                      isActive
+                        ? "bg-indigo-600 text-white shadow-sm dark:bg-indigo-500"
+                        : "text-slate-600 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800"
+                    }`}
+                  >
+                    <span aria-hidden="true">{option.icon}</span>
+                    <span>{t(option.labelKey)}</span>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+
+        <header className="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-100 transition dark:bg-slate-950 dark:ring-slate-800">
+          <h1 className="text-2xl font-semibold text-slate-900 dark:text-slate-100">{t("appTitle")}</h1>
+          <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">{t("appDescription")}</p>
+          <label className="mt-6 flex cursor-pointer flex-col items-center gap-2 rounded-xl border-2 border-dashed border-slate-300 p-6 text-center transition hover:border-indigo-400 dark:border-slate-700 dark:hover:border-indigo-400">
+            <span className="text-base font-medium text-slate-700 dark:text-slate-200">{t("uploadCallToAction")}</span>
+            <span className="text-sm text-slate-500 dark:text-slate-400">{t("uploadDetails")}</span>
             <input type="file" accept=".xlsx,.xlsm" className="hidden" onChange={handleFileChange} ref={fileInputRef} />
           </label>
         </header>
 
-        <article className="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-100">
+        <article className="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-100 transition dark:bg-slate-950 dark:ring-slate-800">
           <header className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
             <div>
-              <h2 className="text-xl font-semibold text-slate-900">Règles détectées</h2>
-              <p className="text-sm text-slate-500">
-                Interprétation lisible de la feuille ValidationRules et édition directement dans l'interface.
-              </p>
+              <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">{t("detectedRulesTitle")}</h2>
+              <p className="text-sm text-slate-500 dark:text-slate-400">{t("detectedRulesDescription")}</p>
             </div>
             <div className="flex items-center gap-3">
-              <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-600">
-                {rules.length} règle{rules.length > 1 ? "s" : ""}
+              <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-600 dark:bg-slate-800 dark:text-slate-300">
+                {ruleBadge}
               </span>
               <button
                 type="button"
                 onClick={addRule}
-                className="inline-flex items-center rounded-lg border border-indigo-600 px-4 py-2 text-sm font-semibold text-indigo-600 transition hover:bg-indigo-50"
+                className="inline-flex items-center rounded-lg border border-indigo-600 px-4 py-2 text-sm font-semibold text-indigo-600 transition hover:bg-indigo-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 dark:hover:bg-indigo-500/10"
               >
-                Ajouter une règle
+                {t("addRule")}
               </button>
             </div>
           </header>
 
-          <div className="mt-6 rounded-xl border border-indigo-100 bg-indigo-50 p-4 text-sm text-indigo-900">
-            <p className="font-medium">Astuce d'utilisation</p>
+          <div className="mt-6 rounded-xl border border-indigo-100 bg-indigo-50 p-4 text-sm text-indigo-900 dark:border-indigo-500/40 dark:bg-indigo-500/10 dark:text-indigo-100">
+            <p className="font-medium">{t("usageTipsTitle")}</p>
             <ul className="mt-2 list-disc space-y-1 pl-4">
-              <li>Activez ou désactivez les contrôles comme dans la feuille Excel.</li>
-              <li>Basculer sur « Instruction » permet de référencer une feuille annexe avec SHEET=NomFeuille.</li>
-              <li>Ajoutez autant de valeurs autorisées que nécessaire en saisissant une valeur par ligne.</li>
+              <li>{t("usageTipsBullet1")}</li>
+              <li>{t("usageTipsBullet2")}</li>
+              <li>{t("usageTipsBullet3")}</li>
             </ul>
           </div>
 
           {rules.length === 0 ? (
-            <div className="mt-6 rounded-xl border border-slate-200 bg-slate-50 p-6 text-center text-sm text-slate-600">
-              <p>
-                Aucune règle à afficher pour l'instant. Importez un fichier ou créez votre première règle pour démarrer la
-                configuration.
-              </p>
+            <div className="mt-6 rounded-xl border border-slate-200 bg-slate-50 p-6 text-center text-sm text-slate-600 transition dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300">
+              <p>{t("noRulesMessage")}</p>
               <button
                 type="button"
                 onClick={addRule}
-                className="mt-4 inline-flex items-center rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-700"
+                className="mt-4 inline-flex items-center rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
               >
-                Créer une première règle
+                {t("createFirstRule")}
               </button>
             </div>
           ) : (
@@ -420,118 +721,134 @@ export default function HomePage() {
               {rules.map((rule) => {
                 const fieldIsEmpty = rule.field.trim().length === 0;
                 return (
-                  <div key={rule.id} className="rounded-xl border border-slate-200 shadow-sm">
-                    <div className="flex flex-col gap-4 border-b border-slate-100 bg-slate-50 p-5 md:flex-row md:items-end">
+                  <div key={rule.id} className="rounded-xl border border-slate-200 shadow-sm transition dark:border-slate-800">
+                    <div className="flex flex-col gap-4 border-b border-slate-100 bg-slate-50 p-5 transition dark:border-slate-800 dark:bg-slate-900 md:flex-row md:items-end">
                       <div className="flex-1">
-                        <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">Champ</label>
+                        <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                          {t("fieldLabel")}
+                        </label>
                         <input
                           type="text"
                           value={rule.field}
                           onChange={(event) => updateRule(rule.id, { field: event.target.value })}
-                          className={`mt-2 w-full rounded-lg border px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 ${fieldIsEmpty ? "border-rose-400" : "border-slate-200"}`}
-                          placeholder="Nom du champ dans la feuille Template"
+                          className={`mt-2 w-full rounded-lg border px-3 py-2 text-sm shadow-sm transition focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:bg-slate-950 dark:text-slate-100 dark:focus:ring-indigo-500 ${
+                            fieldIsEmpty ? "border-rose-400" : "border-slate-200 dark:border-slate-700"
+                          }`}
+                          placeholder={t("fieldPlaceholder")}
                         />
                         {fieldIsEmpty && (
-                          <p className="mt-1 text-xs text-rose-600">Le nom du champ est requis pour lancer la validation.</p>
+                          <p className="mt-1 text-xs text-rose-600 dark:text-rose-400">{t("fieldRequired")}</p>
                         )}
                       </div>
                       <button
                         type="button"
                         onClick={() => removeRule(rule.id)}
-                        className="inline-flex items-center justify-center rounded-lg border border-rose-200 px-3 py-2 text-xs font-semibold text-rose-600 transition hover:bg-rose-50"
+                        className="inline-flex items-center justify-center rounded-lg border border-rose-200 px-3 py-2 text-xs font-semibold text-rose-600 transition hover:bg-rose-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-500 dark:border-rose-500/40 dark:text-rose-300 dark:hover:bg-rose-500/10"
                       >
-                        Supprimer
+                        {t("removeRule")}
                       </button>
                     </div>
 
                     <div className="grid gap-6 p-5 md:grid-cols-2">
                       <div className="space-y-5">
-                        <fieldset className="grid grid-cols-2 gap-3 text-sm text-slate-700">
+                        <fieldset className="grid grid-cols-2 gap-3 text-sm text-slate-700 dark:text-slate-300">
                           <label className="flex items-center gap-2">
                             <input
                               type="checkbox"
                               checked={rule.checked}
                               onChange={(event) => updateRule(rule.id, { checked: event.target.checked })}
-                              className="h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500"
+                              className="h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500 dark:border-slate-600"
                             />
-                            Checker activé
+                            <span>{t("toggleChecked")}</span>
                           </label>
                           <label className="flex items-center gap-2">
                             <input
                               type="checkbox"
                               checked={rule.required}
                               onChange={(event) => updateRule(rule.id, { required: event.target.checked })}
-                              className="h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500"
+                              className="h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500 dark:border-slate-600"
                             />
-                            Champ obligatoire
+                            <span>{t("toggleRequired")}</span>
                           </label>
                         </fieldset>
 
                         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
                           <div>
-                            <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">Taille min</label>
+                            <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                              {t("minLengthLabel")}
+                            </label>
                             <input
                               type="number"
                               value={rule.minLength ?? ""}
-                              onChange={(event) => updateRule(rule.id, { minLength: parseNumberInput(event.target.value) })}
-                              className="mt-2 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
-                              placeholder="Optionnel"
+                              onChange={(event) =>
+                                updateRule(rule.id, { minLength: parseNumberInput(event.target.value) })
+                              }
+                              className="mt-2 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm transition focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100"
+                              placeholder={t("optionalPlaceholder")}
                             />
                           </div>
                           <div>
-                            <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">Taille max</label>
+                            <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                              {t("maxLengthLabel")}
+                            </label>
                             <input
                               type="number"
                               value={rule.maxLength ?? ""}
-                              onChange={(event) => updateRule(rule.id, { maxLength: parseNumberInput(event.target.value) })}
-                              className="mt-2 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
-                              placeholder="Optionnel"
+                              onChange={(event) =>
+                                updateRule(rule.id, { maxLength: parseNumberInput(event.target.value) })
+                              }
+                              className="mt-2 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm transition focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100"
+                              placeholder={t("optionalPlaceholder")}
                             />
                           </div>
                         </div>
 
                         <div>
-                          <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">Pattern (RegExp)</label>
+                          <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                            {t("patternLabel")}
+                          </label>
                           <input
                             type="text"
                             value={rule.pattern ?? ""}
                             onChange={(event) => updateRule(rule.id, { pattern: event.target.value || undefined })}
-                            className="mt-2 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
-                            placeholder="Ex: ^[0-9]{5}$"
+                            className="mt-2 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm transition focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100"
+                            placeholder={t("patternPlaceholder")}
                           />
                         </div>
 
                         <div>
-                          <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">Règle personnalisée</label>
+                          <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                            {t("customRuleLabel")}
+                          </label>
                           <input
                             type="text"
                             value={rule.customRule ?? ""}
                             onChange={(event) => updateRule(rule.id, { customRule: event.target.value || undefined })}
-                            className="mt-2 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
-                            placeholder="Nom de la fonction Python personnalisée"
+                            className="mt-2 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm transition focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100"
+                            placeholder={t("customRulePlaceholder")}
                           />
                         </div>
                       </div>
 
                       <div className="space-y-5">
                         <div>
-                          <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">
-                            Source des valeurs autorisées
+                          <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                            {t("allowedSourceLabel")}
                           </label>
                           <select
                             value={rule.allowedType}
                             onChange={(event) => updateRule(rule.id, { allowedType: event.target.value as AllowedType })}
-                            className="mt-2 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+                            className="mt-2 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm transition focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100"
                           >
-                            <option value="list">Liste de valeurs</option>
-                            <option value="instruction">Instruction (VALUE=, SHEET=, etc.)</option>
+                            <option value="list">{t("allowedSourceList")}</option>
+                            <option value="instruction">{t("allowedSourceInstruction")}</option>
                           </select>
                         </div>
 
                         {rule.allowedType === "list" ? (
                           <div>
-                            <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">
-                              Valeurs autorisées
+                            <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                              {t("allowedValuesLabel")}
                             </label>
                             <textarea
                               value={rule.allowedValues.join("\n")}
@@ -543,18 +860,16 @@ export default function HomePage() {
                                     .filter((value) => value.length > 0),
                                 })
                               }
-                              className="mt-2 h-28 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
-                              placeholder="Saisissez une valeur par ligne"
+                              className="mt-2 h-28 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm transition focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100"
+                              placeholder={t("allowedValuesPlaceholder")}
                             />
-                            <p className="mt-1 text-xs text-slate-500">
-                              Ces valeurs seront converties en instruction VALUE= lors de la validation.
-                            </p>
+                            <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">{t("allowedValuesHelper")}</p>
                             {rule.allowedValues.length > 0 && (
                               <div className="mt-3 flex flex-wrap gap-2">
                                 {rule.allowedValues.map((value) => (
                                   <span
                                     key={`${rule.id}-${value}`}
-                                    className="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-700"
+                                    className="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-700 dark:bg-slate-800 dark:text-slate-200"
                                   >
                                     {value}
                                   </span>
@@ -564,18 +879,16 @@ export default function HomePage() {
                           </div>
                         ) : (
                           <div>
-                            <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">
-                              Instruction AllowedValues
+                            <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                              {t("allowedInstructionLabel")}
                             </label>
                             <textarea
                               value={rule.allowedInstruction}
                               onChange={(event) => updateRule(rule.id, { allowedInstruction: event.target.value })}
-                              className="mt-2 h-28 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
-                              placeholder="Ex: SHEET=AnnuaireCodes ou VALUE=A;B;C"
+                              className="mt-2 h-28 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm transition focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100"
+                              placeholder={t("allowedInstructionPlaceholder")}
                             />
-                            <p className="mt-1 text-xs text-slate-500">
-                              Utilisez SHEET=NomFeuille pour charger une feuille annexe ou toute instruction personnalisée.
-                            </p>
+                            <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">{t("allowedInstructionHelper")}</p>
                           </div>
                         )}
                       </div>
@@ -587,31 +900,31 @@ export default function HomePage() {
           )}
         </article>
 
-        <footer className="flex flex-col gap-4 rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-100 md:flex-row md:items-center md:justify-between">
-          <p className="text-sm text-slate-600">{status}</p>
+        <footer className="flex flex-col gap-4 rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-100 transition dark:bg-slate-950 dark:ring-slate-800 md:flex-row md:items-center md:justify-between">
+          <p className="text-sm text-slate-600 dark:text-slate-300">{statusText}</p>
           <div className="flex flex-wrap gap-3">
             <button
               type="button"
               onClick={() => resetSelection()}
               disabled={!file || isSubmitting}
-              className="rounded-lg border border-rose-500 px-4 py-2 text-sm font-semibold text-rose-600 shadow-sm disabled:cursor-not-allowed disabled:opacity-50"
+              className="rounded-lg border border-rose-500 px-4 py-2 text-sm font-semibold text-rose-600 shadow-sm transition hover:bg-rose-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-rose-400 dark:text-rose-300 dark:hover:bg-rose-500/10"
             >
-              Supprimer le fichier
+              {t("deleteFile")}
             </button>
             <button
               type="button"
               disabled={!file || isSubmitting || hasMissingField}
               onClick={launchValidation}
-              className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow disabled:cursor-not-allowed disabled:bg-slate-300"
+              className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-indigo-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 disabled:cursor-not-allowed disabled:bg-slate-300 dark:disabled:bg-slate-700"
             >
-              {isSubmitting ? "Validation…" : "Lancer la validation Python"}
+              {isSubmitting ? t("validating") : t("launchValidation")}
             </button>
             {reportUrl && (
               <a
                 href={reportUrl}
-                className="rounded-lg border border-indigo-600 px-4 py-2 text-sm font-semibold text-indigo-600"
+                className="rounded-lg border border-indigo-600 px-4 py-2 text-sm font-semibold text-indigo-600 transition hover:bg-indigo-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 dark:hover:bg-indigo-500/10"
               >
-                Télécharger le rapport
+                {t("downloadReport")}
               </a>
             )}
           </div>

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,4 +1,6 @@
-﻿import type { Config } from "tailwindcss";
+const config: Config = {
+  darkMode: "class",
+
 
 const config: Config = {
   content: [


### PR DESCRIPTION
## Summary
- add translation utilities and toggles so the interface can switch between French and English
- wire in a light/dark theme preference with Tailwind class-based styling and persistence
- refresh global and layout styling to support dark mode backgrounds and text colors throughout the app

## Testing
- npm run lint *(fails: command prompts for interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68e3e373f8c4832bb08291303bbaa2c0