### PR TITLE
Add Tailwind dark mode toggle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+node_modules/
+.next/
+.env*
+.DS_Store
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1,3 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 :root {
   color-scheme: light;
 }
@@ -13,14 +17,4 @@ body {
 
 .dark body {
   @apply bg-slate-950 text-slate-100;
-@tailwind utilities;
-
-:root {
-  color-scheme: light;
-}
-
-body {
-  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  background-color: #f8fafc;
-  color: #0f172a;
 }

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1,5 +1,18 @@
-﻿@tailwind base;
-@tailwind components;
+:root {
+  color-scheme: light;
+}
+
+.dark {
+  color-scheme: dark;
+}
+
+body {
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  @apply bg-slate-50 text-slate-900 transition-colors duration-300;
+}
+
+.dark body {
+  @apply bg-slate-950 text-slate-100;
 @tailwind utilities;
 
 :root {

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -23,17 +23,3 @@ export default function RootLayout({
     </html>
   );
 }
-
-};
-
-export default function RootLayout({
-  children,
-}: {
-  children: ReactNode;
-}) {
-  return (
-    <html lang="fr">
-      <body className="min-h-screen bg-slate-50">{children}</body>
-    </html>
-  );
-}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,10 +1,29 @@
-﻿import "./globals.css";
-import type { Metadata } from "next";
-import type { ReactNode } from "react";
-
-export const metadata: Metadata = {
-  title: "Validation DMF",
-  description: "Interface pour visualiser et lancer la validation DMF",
+import "./globals.css";
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+import { ThemeToggle } from "../components/theme-toggle";
+
+export const metadata: Metadata = {
+  title: "Validation DMF",
+  description: "Interface pour visualiser et lancer la validation DMF",
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  return (
+    <html lang="fr" suppressHydrationWarning>
+      <body className="min-h-screen bg-slate-50 text-slate-900 transition-colors duration-300 dark:bg-slate-950 dark:text-slate-100">
+        <ThemeToggle />
+        {children}
+      </body>
+    </html>
+  );
+}
+
 };
 
 export default function RootLayout({

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -355,44 +355,44 @@ export default function HomePage() {
   }
 
   return (
-    <main className="min-h-screen bg-slate-50 p-6 md:p-10">
+    <main className="min-h-screen bg-slate-50 p-6 transition-colors duration-300 dark:bg-slate-950 md:p-10">
       <section className="mx-auto flex max-w-5xl flex-col gap-8">
-        <header className="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-100">
-          <h1 className="text-2xl font-semibold text-slate-900">Validation DMF</h1>
-          <p className="mt-2 text-sm text-slate-600">
+        <header className="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-100 dark:bg-slate-900 dark:ring-slate-800">
+          <h1 className="text-2xl font-semibold text-slate-900 dark:text-slate-100">Validation DMF</h1>
+          <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">
             Déposez votre template Excel pour visualiser les règles, personnalisez-les dans l'application puis lancez la
             validation Python.
           </p>
-          <label className="mt-6 flex cursor-pointer flex-col items-center gap-2 rounded-xl border-2 border-dashed border-slate-300 p-6 text-center transition hover:border-indigo-400">
-            <span className="text-base font-medium text-slate-700">Déposer un fichier Excel</span>
-            <span className="text-sm text-slate-500">Feuilles attendues: Template &amp; ValidationRules</span>
+          <label className="mt-6 flex cursor-pointer flex-col items-center gap-2 rounded-xl border-2 border-dashed border-slate-300 p-6 text-center transition hover:border-indigo-400 dark:border-slate-600 dark:bg-slate-900/40">
+            <span className="text-base font-medium text-slate-700 dark:text-slate-200">Déposer un fichier Excel</span>
+            <span className="text-sm text-slate-500 dark:text-slate-400">Feuilles attendues: Template &amp; ValidationRules</span>
             <input type="file" accept=".xlsx,.xlsm" className="hidden" onChange={handleFileChange} ref={fileInputRef} />
           </label>
         </header>
 
-        <article className="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-100">
+        <article className="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-100 dark:bg-slate-900 dark:ring-slate-800">
           <header className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
             <div>
-              <h2 className="text-xl font-semibold text-slate-900">Règles détectées</h2>
-              <p className="text-sm text-slate-500">
+              <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">Règles détectées</h2>
+              <p className="text-sm text-slate-500 dark:text-slate-400">
                 Interprétation lisible de la feuille ValidationRules et édition directement dans l'interface.
               </p>
             </div>
             <div className="flex items-center gap-3">
-              <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-600">
+              <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-600 dark:bg-slate-800 dark:text-slate-200">
                 {rules.length} règle{rules.length > 1 ? "s" : ""}
               </span>
               <button
                 type="button"
                 onClick={addRule}
-                className="inline-flex items-center rounded-lg border border-indigo-600 px-4 py-2 text-sm font-semibold text-indigo-600 transition hover:bg-indigo-50"
+                className="inline-flex items-center rounded-lg border border-indigo-600 px-4 py-2 text-sm font-semibold text-indigo-600 transition hover:bg-indigo-50 dark:border-indigo-400 dark:text-indigo-300 dark:hover:bg-indigo-500/10"
               >
                 Ajouter une règle
               </button>
             </div>
           </header>
 
-          <div className="mt-6 rounded-xl border border-indigo-100 bg-indigo-50 p-4 text-sm text-indigo-900">
+          <div className="mt-6 rounded-xl border border-indigo-100 bg-indigo-50 p-4 text-sm text-indigo-900 dark:border-indigo-900 dark:bg-indigo-950/40 dark:text-indigo-200">
             <p className="font-medium">Astuce d'utilisation</p>
             <ul className="mt-2 list-disc space-y-1 pl-4">
               <li>Activez ou désactivez les contrôles comme dans la feuille Excel.</li>
@@ -402,7 +402,7 @@ export default function HomePage() {
           </div>
 
           {rules.length === 0 ? (
-            <div className="mt-6 rounded-xl border border-slate-200 bg-slate-50 p-6 text-center text-sm text-slate-600">
+            <div className="mt-6 rounded-xl border border-slate-200 bg-slate-50 p-6 text-center text-sm text-slate-600 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300">
               <p>
                 Aucune règle à afficher pour l'instant. Importez un fichier ou créez votre première règle pour démarrer la
                 configuration.
@@ -420,25 +420,25 @@ export default function HomePage() {
               {rules.map((rule) => {
                 const fieldIsEmpty = rule.field.trim().length === 0;
                 return (
-                  <div key={rule.id} className="rounded-xl border border-slate-200 shadow-sm">
-                    <div className="flex flex-col gap-4 border-b border-slate-100 bg-slate-50 p-5 md:flex-row md:items-end">
+                  <div key={rule.id} className="rounded-xl border border-slate-200 shadow-sm dark:border-slate-700 dark:bg-slate-900">
+                    <div className="flex flex-col gap-4 border-b border-slate-100 bg-slate-50 p-5 dark:border-slate-800 dark:bg-slate-950 md:flex-row md:items-end">
                       <div className="flex-1">
-                        <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">Champ</label>
+                        <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Champ</label>
                         <input
                           type="text"
                           value={rule.field}
                           onChange={(event) => updateRule(rule.id, { field: event.target.value })}
-                          className={`mt-2 w-full rounded-lg border px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 ${fieldIsEmpty ? "border-rose-400" : "border-slate-200"}`}
+                          className={`mt-2 w-full rounded-lg border px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:bg-slate-950 dark:text-slate-100 dark:placeholder-slate-400 ${fieldIsEmpty ? "border-rose-400 dark:border-rose-400" : "border-slate-200 dark:border-slate-700"}`}
                           placeholder="Nom du champ dans la feuille Template"
                         />
                         {fieldIsEmpty && (
-                          <p className="mt-1 text-xs text-rose-600">Le nom du champ est requis pour lancer la validation.</p>
+                          <p className="mt-1 text-xs text-rose-600 dark:text-rose-400">Le nom du champ est requis pour lancer la validation.</p>
                         )}
                       </div>
                       <button
                         type="button"
                         onClick={() => removeRule(rule.id)}
-                        className="inline-flex items-center justify-center rounded-lg border border-rose-200 px-3 py-2 text-xs font-semibold text-rose-600 transition hover:bg-rose-50"
+                        className="inline-flex items-center justify-center rounded-lg border border-rose-200 px-3 py-2 text-xs font-semibold text-rose-600 transition hover:bg-rose-50 dark:border-rose-400/40 dark:text-rose-300 dark:hover:bg-rose-500/10"
                       >
                         Supprimer
                       </button>
@@ -446,13 +446,13 @@ export default function HomePage() {
 
                     <div className="grid gap-6 p-5 md:grid-cols-2">
                       <div className="space-y-5">
-                        <fieldset className="grid grid-cols-2 gap-3 text-sm text-slate-700">
+                        <fieldset className="grid grid-cols-2 gap-3 text-sm text-slate-700 dark:text-slate-200">
                           <label className="flex items-center gap-2">
                             <input
                               type="checkbox"
                               checked={rule.checked}
                               onChange={(event) => updateRule(rule.id, { checked: event.target.checked })}
-                              className="h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500"
+                              className="h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500 dark:border-slate-600 dark:bg-slate-900 dark:text-indigo-400 dark:focus:ring-indigo-400"
                             />
                             Checker activé
                           </label>
@@ -461,7 +461,7 @@ export default function HomePage() {
                               type="checkbox"
                               checked={rule.required}
                               onChange={(event) => updateRule(rule.id, { required: event.target.checked })}
-                              className="h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500"
+                              className="h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500 dark:border-slate-600 dark:bg-slate-900 dark:text-indigo-400 dark:focus:ring-indigo-400"
                             />
                             Champ obligatoire
                           </label>
@@ -469,45 +469,45 @@ export default function HomePage() {
 
                         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
                           <div>
-                            <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">Taille min</label>
+                            <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Taille min</label>
                             <input
                               type="number"
                               value={rule.minLength ?? ""}
                               onChange={(event) => updateRule(rule.id, { minLength: parseNumberInput(event.target.value) })}
-                              className="mt-2 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+                              className="mt-2 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:placeholder-slate-400"
                               placeholder="Optionnel"
                             />
                           </div>
                           <div>
-                            <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">Taille max</label>
+                            <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Taille max</label>
                             <input
                               type="number"
                               value={rule.maxLength ?? ""}
                               onChange={(event) => updateRule(rule.id, { maxLength: parseNumberInput(event.target.value) })}
-                              className="mt-2 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+                              className="mt-2 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:placeholder-slate-400"
                               placeholder="Optionnel"
                             />
                           </div>
                         </div>
 
                         <div>
-                          <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">Pattern (RegExp)</label>
+                          <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Pattern (RegExp)</label>
                           <input
                             type="text"
                             value={rule.pattern ?? ""}
                             onChange={(event) => updateRule(rule.id, { pattern: event.target.value || undefined })}
-                            className="mt-2 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+                            className="mt-2 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:placeholder-slate-400"
                             placeholder="Ex: ^[0-9]{5}$"
                           />
                         </div>
 
                         <div>
-                          <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">Règle personnalisée</label>
+                          <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Règle personnalisée</label>
                           <input
                             type="text"
                             value={rule.customRule ?? ""}
                             onChange={(event) => updateRule(rule.id, { customRule: event.target.value || undefined })}
-                            className="mt-2 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+                            className="mt-2 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:placeholder-slate-400"
                             placeholder="Nom de la fonction Python personnalisée"
                           />
                         </div>
@@ -515,13 +515,13 @@ export default function HomePage() {
 
                       <div className="space-y-5">
                         <div>
-                          <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                          <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
                             Source des valeurs autorisées
                           </label>
                           <select
                             value={rule.allowedType}
                             onChange={(event) => updateRule(rule.id, { allowedType: event.target.value as AllowedType })}
-                            className="mt-2 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+                            className="mt-2 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100"
                           >
                             <option value="list">Liste de valeurs</option>
                             <option value="instruction">Instruction (VALUE=, SHEET=, etc.)</option>
@@ -530,7 +530,7 @@ export default function HomePage() {
 
                         {rule.allowedType === "list" ? (
                           <div>
-                            <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                            <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
                               Valeurs autorisées
                             </label>
                             <textarea
@@ -543,10 +543,10 @@ export default function HomePage() {
                                     .filter((value) => value.length > 0),
                                 })
                               }
-                              className="mt-2 h-28 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+                              className="mt-2 h-28 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:placeholder-slate-400"
                               placeholder="Saisissez une valeur par ligne"
                             />
-                            <p className="mt-1 text-xs text-slate-500">
+                            <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
                               Ces valeurs seront converties en instruction VALUE= lors de la validation.
                             </p>
                             {rule.allowedValues.length > 0 && (
@@ -554,7 +554,7 @@ export default function HomePage() {
                                 {rule.allowedValues.map((value) => (
                                   <span
                                     key={`${rule.id}-${value}`}
-                                    className="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-700"
+                                    className="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-700 dark:bg-slate-800 dark:text-slate-200"
                                   >
                                     {value}
                                   </span>
@@ -564,16 +564,16 @@ export default function HomePage() {
                           </div>
                         ) : (
                           <div>
-                            <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                            <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
                               Instruction AllowedValues
                             </label>
                             <textarea
                               value={rule.allowedInstruction}
                               onChange={(event) => updateRule(rule.id, { allowedInstruction: event.target.value })}
-                              className="mt-2 h-28 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+                              className="mt-2 h-28 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:placeholder-slate-400"
                               placeholder="Ex: SHEET=AnnuaireCodes ou VALUE=A;B;C"
                             />
-                            <p className="mt-1 text-xs text-slate-500">
+                            <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
                               Utilisez SHEET=NomFeuille pour charger une feuille annexe ou toute instruction personnalisée.
                             </p>
                           </div>
@@ -587,14 +587,14 @@ export default function HomePage() {
           )}
         </article>
 
-        <footer className="flex flex-col gap-4 rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-100 md:flex-row md:items-center md:justify-between">
-          <p className="text-sm text-slate-600">{status}</p>
+        <footer className="flex flex-col gap-4 rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-100 dark:bg-slate-900 dark:ring-slate-800 md:flex-row md:items-center md:justify-between">
+          <p className="text-sm text-slate-600 dark:text-slate-300">{status}</p>
           <div className="flex flex-wrap gap-3">
             <button
               type="button"
               onClick={() => resetSelection()}
               disabled={!file || isSubmitting}
-              className="rounded-lg border border-rose-500 px-4 py-2 text-sm font-semibold text-rose-600 shadow-sm disabled:cursor-not-allowed disabled:opacity-50"
+              className="rounded-lg border border-rose-500 px-4 py-2 text-sm font-semibold text-rose-600 shadow-sm transition disabled:cursor-not-allowed disabled:opacity-50 dark:border-rose-400 dark:text-rose-300"
             >
               Supprimer le fichier
             </button>
@@ -602,14 +602,14 @@ export default function HomePage() {
               type="button"
               disabled={!file || isSubmitting || hasMissingField}
               onClick={launchValidation}
-              className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow disabled:cursor-not-allowed disabled:bg-slate-300"
+              className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow transition disabled:cursor-not-allowed disabled:bg-slate-300 dark:disabled:bg-slate-700"
             >
               {isSubmitting ? "Validation…" : "Lancer la validation Python"}
             </button>
             {reportUrl && (
               <a
                 href={reportUrl}
-                className="rounded-lg border border-indigo-600 px-4 py-2 text-sm font-semibold text-indigo-600"
+                className="rounded-lg border border-indigo-600 px-4 py-2 text-sm font-semibold text-indigo-600 transition hover:bg-indigo-50 dark:border-indigo-400 dark:text-indigo-300 dark:hover:bg-indigo-500/10"
               >
                 Télécharger le rapport
               </a>

--- a/frontend/components/theme-toggle.tsx
+++ b/frontend/components/theme-toggle.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+type Theme = "light" | "dark";
+
+function SunIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      className={className}
+      aria-hidden
+    >
+      <circle cx="12" cy="12" r="4.5" />
+      <path d="M12 3v2.25M12 18.75V21M4.221 4.221l1.59 1.59M18.189 18.189l1.59 1.59M3 12h2.25M18.75 12H21M4.221 19.779l1.59-1.59M18.189 5.811l1.59-1.59" />
+    </svg>
+  );
+}
+
+function MoonIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      className={className}
+      aria-hidden
+    >
+      <path
+        d="M21 12.79A9 9 0 0 1 11.21 3 6.75 6.75 0 1 0 21 12.79Z"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+export function ThemeToggle() {
+  const [theme, setTheme] = useState<Theme>("light");
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    const stored = window.localStorage.getItem("dmf-theme");
+    const prefersDark = typeof window.matchMedia === "function" ? window.matchMedia("(prefers-color-scheme: dark)").matches : false;
+    const nextTheme: Theme = stored === "light" || stored === "dark" ? stored : prefersDark ? "dark" : "light";
+    const root = document.documentElement;
+    root.classList.toggle("dark", nextTheme === "dark");
+    root.style.colorScheme = nextTheme;
+    setTheme(nextTheme);
+    setMounted(true);
+  }, []);
+
+  useEffect(() => {
+    if (!mounted) return;
+    const root = document.documentElement;
+    root.classList.toggle("dark", theme === "dark");
+    root.style.colorScheme = theme;
+    window.localStorage.setItem("dmf-theme", theme);
+  }, [mounted, theme]);
+
+  const handleSetTheme = (nextTheme: Theme) => {
+    if (nextTheme === theme) return;
+    setTheme(nextTheme);
+  };
+
+  return (
+    <div className="fixed right-6 top-6 z-50 flex items-center gap-1 rounded-full border border-slate-200 bg-white/80 p-1 shadow-sm backdrop-blur-md dark:border-slate-700 dark:bg-slate-900/80">
+      <button
+        type="button"
+        onClick={() => handleSetTheme("light")}
+        className={`flex items-center gap-2 rounded-full px-3 py-1.5 text-sm font-medium transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500 ${theme === "light" ? "bg-indigo-500 text-white shadow" : "text-slate-600 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800/80"}`}
+        aria-pressed={theme === "light"}
+        title="Activer le thème clair"
+      >
+        <SunIcon className="h-4 w-4" />
+        <span className="hidden sm:inline">Clair</span>
+      </button>
+      <button
+        type="button"
+        onClick={() => handleSetTheme("dark")}
+        className={`flex items-center gap-2 rounded-full px-3 py-1.5 text-sm font-medium transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500 ${theme === "dark" ? "bg-indigo-500 text-white shadow" : "text-slate-600 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800/80"}`}
+        aria-pressed={theme === "dark"}
+        title="Activer le thème sombre"
+      >
+        <MoonIcon className="h-4 w-4" />
+        <span className="hidden sm:inline">Sombre</span>
+      </button>
+    </div>
+  );
+}

--- a/frontend/components/theme-toggle.tsx
+++ b/frontend/components/theme-toggle.tsx
@@ -64,33 +64,21 @@ export function ThemeToggle() {
     window.localStorage.setItem("dmf-theme", theme);
   }, [mounted, theme]);
 
-  const handleSetTheme = (nextTheme: Theme) => {
-    if (nextTheme === theme) return;
-    setTheme(nextTheme);
+  const toggleTheme = () => {
+    setTheme((current) => (current === "dark" ? "light" : "dark"));
   };
 
+  const isDark = theme === "dark";
+
   return (
-    <div className="fixed right-6 top-6 z-50 flex items-center gap-1 rounded-full border border-slate-200 bg-white/80 p-1 shadow-sm backdrop-blur-md dark:border-slate-700 dark:bg-slate-900/80">
-      <button
-        type="button"
-        onClick={() => handleSetTheme("light")}
-        className={`flex items-center gap-2 rounded-full px-3 py-1.5 text-sm font-medium transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500 ${theme === "light" ? "bg-indigo-500 text-white shadow" : "text-slate-600 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800/80"}`}
-        aria-pressed={theme === "light"}
-        title="Activer le thème clair"
-      >
-        <SunIcon className="h-4 w-4" />
-        <span className="hidden sm:inline">Clair</span>
-      </button>
-      <button
-        type="button"
-        onClick={() => handleSetTheme("dark")}
-        className={`flex items-center gap-2 rounded-full px-3 py-1.5 text-sm font-medium transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500 ${theme === "dark" ? "bg-indigo-500 text-white shadow" : "text-slate-600 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800/80"}`}
-        aria-pressed={theme === "dark"}
-        title="Activer le thème sombre"
-      >
-        <MoonIcon className="h-4 w-4" />
-        <span className="hidden sm:inline">Sombre</span>
-      </button>
-    </div>
+    <button
+      type="button"
+      onClick={toggleTheme}
+      className="fixed right-6 top-6 z-50 flex h-10 w-10 items-center justify-center rounded-full border border-slate-200 bg-white/80 shadow-sm backdrop-blur-md transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500 dark:border-slate-700 dark:bg-slate-900/80"
+      title={isDark ? "Passer au theme clair" : "Passer au theme sombre"}
+      aria-label={isDark ? "Passer au theme clair" : "Passer au theme sombre"}
+    >
+      {isDark ? <SunIcon className="h-5 w-5 text-amber-400" /> : <MoonIcon className="h-5 w-5 text-slate-600 dark:text-slate-200" />}
+    </button>
   );
 }

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,6 +1,15 @@
-﻿import type { Config } from "tailwindcss";
-
-const config: Config = {
+const config: Config = {
+  darkMode: "class",
+  content: [
+    "./app/**/*.{js,ts,jsx,tsx}",
+    "./components/**/*.{js,ts,jsx,tsx}",
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};
+
   content: [
     "./app/**/*.{js,ts,jsx,tsx}",
     "./components/**/*.{js,ts,jsx,tsx}",

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,23 +1,12 @@
+import type { Config } from "tailwindcss";
+
 const config: Config = {
   darkMode: "class",
-  content: [
-    "./app/**/*.{js,ts,jsx,tsx}",
-    "./components/**/*.{js,ts,jsx,tsx}",
-  ],
+  content: ["./app/**/*.{js,ts,jsx,tsx}", "./components/**/*.{js,ts,jsx,tsx}"],
   theme: {
     extend: {},
   },
   plugins: [],
 };
-
-  content: [
-    "./app/**/*.{js,ts,jsx,tsx}",
-    "./components/**/*.{js,ts,jsx,tsx}",
-  ],
-  theme: {
-    extend: {},
-  },
-  plugins: [],
-};
-
+
 export default config;


### PR DESCRIPTION
## Summary
- add a reusable ThemeToggle bar with sun and moon actions and persist the preference
- switch Tailwind to class-based dark mode and update global/layout styles accordingly
- refresh page components with dark-mode colour tokens and add a gitignore for local artefacts

## Testing
- `npm run lint` *(fails: interactive Next.js ESLint setup prompt in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e3ee614dc0832b970b13e93e877169