### PR TITLE
Use OS tmp storage for validation artifacts

### DIFF
--- a/frontend/app/api/reports/[filename]/route.ts
+++ b/frontend/app/api/reports/[filename]/route.ts
@@ -1,9 +1,13 @@
 import { readFile, stat } from "node:fs/promises";
 import path from "node:path";
+import { tmpdir } from "node:os";
 import { NextRequest, NextResponse } from "next/server";
 
 const PROJECT_ROOT = path.resolve(process.cwd(), "..");
-const TMP_DIR = path.join(PROJECT_ROOT, "backend", "tmp");
+const TMP_DIR = path.join(
+  process.env.VALIDATION_TMP_DIR ?? tmpdir(),
+  "dmf-validator",
+);
 
 export async function GET(
   _req: NextRequest,


### PR DESCRIPTION
## Summary
- switch validation API routes to store temporary uploads under the operating system temp directory (or VALDATION_TMP_DIR when provided)
- clean up uploaded Excel and transient rules JSON files once validation completes to avoid clutter
- update the report download API to look for generated workbooks in the new temp location

## Testing
- `npm run lint` *(fails: prompts for interactive ESLint setup so the command was aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68e50b860120832b9935ece2ebfa950e