### PR TITLE
Add landing selector and mapping workflow

### DIFF
--- a/backend/mapping/mapper.py
+++ b/backend/mapping/mapper.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+import pandas as pd
+
+
+class MappingError(Exception):
+    """Raised when the mapping engine fails to produce a result."""
+
+
+def _find_column(source_name: str, template_cols: Iterable[str]) -> str | None:
+    lowered = str(source_name).strip().lower()
+    for col in template_cols:
+        if str(col).strip().lower() == lowered:
+            return str(col)
+    return None
+
+
+def _parse_concat_expression(
+    expression: str, template_row: pd.Series, template_cols: Iterable[str]
+) -> str:
+    cleaned = expression.replace("'CONCAT=", "", 1).replace("CONCAT=", "", 1).strip()
+    parts = [part.strip() for part in cleaned.split("+")]
+    result = ""
+    for part in parts:
+        if part.startswith("'") and part.endswith("'"):
+            result += part.strip("'")
+            continue
+
+        matched_col = _find_column(part, template_cols)
+        if matched_col is None:
+            continue
+
+        value = template_row.get(matched_col, "")
+        result += "" if pd.isna(value) else str(value)
+    return result
+
+
+def _build_result_dataframe(xls: dict[str, pd.DataFrame]) -> pd.DataFrame:
+    try:
+        template = xls["Template"]
+        parameters = xls["Parameters"]
+    except KeyError as exc:  # pragma: no cover - defensive programming
+        raise MappingError("Missing required sheets 'Template' and 'Parameters'.") from exc
+
+    result_df = pd.DataFrame()
+
+    for _, row in parameters.iterrows():
+        target_col = str(row.iloc[0]).strip() if pd.notna(row.iloc[0]) else ""
+        rule = str(row.iloc[1]).strip() if pd.notna(row.iloc[1]) else ""
+
+        if not target_col:
+            continue
+
+        if not rule or rule.lower() == "nan":
+            result_df[target_col] = [""] * len(template)
+            continue
+
+        if rule.startswith("NS="):
+            sequence_template = rule.split("NS=")[-1]
+            num_hashes = sequence_template.count("#")
+            prefix = sequence_template.split("#")[0]
+            result_df[target_col] = [
+                prefix + str(idx + 1).zfill(num_hashes) for idx in range(len(template))
+            ]
+            continue
+
+        if rule.startswith("INVARIABLE="):
+            default_val = rule.split("INVARIABLE=")[-1]
+            result_df[target_col] = [default_val] * len(template)
+            continue
+
+        if rule.startswith("MAPPING="):
+            tail = rule.split("MAPPING=")[-1]
+            if ";" not in tail:
+                raise MappingError("Expected format MAPPING=<column>;<sheet>.")
+
+            value1, mapping_sheet = [segment.strip() for segment in tail.split(";", 1)]
+            mapping_df = xls.get(mapping_sheet)
+            if mapping_df is None:
+                result_df[target_col] = [""] * len(template)
+                continue
+
+            if f"{mapping_sheet}Mapping" in mapping_df.columns:
+                mapping_key_col = str(mapping_df.columns[0])
+                mapping_val_col = f"{mapping_sheet}Mapping"
+            else:
+                if len(mapping_df.columns) < 2:
+                    raise MappingError("Mapping sheet needs at least 2 columns.")
+                mapping_key_col = str(mapping_df.columns[0])
+                mapping_val_col = str(mapping_df.columns[1])
+
+            mapping_dict = dict(zip(mapping_df[mapping_key_col], mapping_df[mapping_val_col]))
+
+            matched_col = _find_column(value1, template.columns)
+            if matched_col is None:
+                result_df[target_col] = [""] * len(template)
+                continue
+
+            original_values = template[matched_col]
+            mapped_values = original_values.map(mapping_dict)
+            final_values = [
+                mapped if pd.notna(mapped) and str(mapped).strip().lower() not in {"", "nan"} else original
+                for mapped, original in zip(mapped_values, original_values)
+            ]
+            result_df[target_col] = final_values
+            continue
+
+        if "CONCAT=" in rule:
+            result_df[target_col] = [
+                _parse_concat_expression(rule, template.iloc[i], template.columns) or ""
+                for i in range(len(template))
+            ]
+            continue
+
+        if "+" in rule:
+            parts = [part.strip() for part in rule.split("+")]
+            concat_values: list[str] = []
+            for i in range(len(template)):
+                concat = ""
+                for part in parts:
+                    matched = _find_column(part, template.columns)
+                    if matched:
+                        val = template.iloc[i][matched]
+                        concat += "" if pd.isna(val) else str(val)
+                    elif part.startswith("'") and part.endswith("'"):
+                        concat += part.strip("'")
+                concat_values.append(concat)
+            result_df[target_col] = concat_values
+            continue
+
+        if rule.startswith("COLUMN="):
+            source_col = rule.split("COLUMN=")[-1].strip()
+            matched_col = _find_column(source_col, template.columns)
+            if matched_col is not None:
+                result_df[target_col] = template[matched_col]
+            else:
+                result_df[target_col] = [""] * len(template)
+            continue
+
+        # Unknown rule -> empty column but keep the header so nothing breaks
+        result_df[target_col] = [""] * len(template)
+
+    return result_df
+
+
+def generate_mapped_workbook(
+    input_excel: str | Path, output_dir: str | Path, output_name: str | None = None
+) -> Path:
+    input_path = Path(input_excel).resolve()
+    output_path = Path(output_dir).resolve()
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    try:
+        xls = pd.read_excel(
+            input_path,
+            sheet_name=None,
+            engine="openpyxl",
+            keep_default_na=False,
+        )
+    except Exception as exc:  # noqa: BLE001
+        raise MappingError(f"Cannot read '{input_path.name}': {exc}") from exc
+
+    try:
+        result_df = _build_result_dataframe(xls)
+    except MappingError:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        raise MappingError(
+            f"Failed to build result for '{input_path.name}': {exc}"
+        ) from exc
+
+    default_name = f"{input_path.stem}_result.xlsx"
+    final_name = (output_name or default_name).strip() or default_name
+    if not final_name.lower().endswith(".xlsx"):
+        final_name = f"{final_name}.xlsx"
+
+    destination = output_path / final_name
+
+    try:
+        result_df.to_excel(destination, index=False)
+    except Exception as exc:  # noqa: BLE001
+        raise MappingError(f"Failed to save '{final_name}': {exc}") from exc
+
+    return destination

--- a/backend/mapping_runner.py
+++ b/backend/mapping_runner.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from backend.mapping.mapper import MappingError, generate_mapped_workbook  # noqa: E402
+
+
+def main() -> int:
+    if len(sys.argv) < 3:
+        print(
+            "Usage: python mapping_runner.py <input_excel> <output_dir> [output_name]",
+            file=sys.stderr,
+        )
+        return 1
+
+    input_path = Path(sys.argv[1]).resolve()
+    output_dir = Path(sys.argv[2]).resolve()
+    output_name = sys.argv[3] if len(sys.argv) > 3 else None
+
+    try:
+        destination = generate_mapped_workbook(input_path, output_dir, output_name)
+    except MappingError as exc:
+        print(f"ERROR:{exc}", file=sys.stderr)
+        return 1
+    except Exception as exc:  # noqa: BLE001
+        print(f"ERROR:{exc}", file=sys.stderr)
+        return 1
+
+    print(f"RESULT:{destination.name}")
+    print(f"INFO:Generated {destination.name}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/frontend/app/api/mapping/route.ts
+++ b/frontend/app/api/mapping/route.ts
@@ -1,0 +1,174 @@
+import { randomUUID } from "node:crypto";
+import { spawn } from "node:child_process";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { NextRequest, NextResponse } from "next/server";
+
+const PROJECT_ROOT = path.resolve(process.cwd(), "..");
+const BACKEND_ROOT = path.join(PROJECT_ROOT, "backend");
+const TMP_DIR = path.join(process.env.VALIDATION_TMP_DIR ?? tmpdir(), "dmf-validator");
+const PYTHON_MAPPER = path.join(BACKEND_ROOT, "mapping_runner.py");
+
+const PYTHON_CANDIDATES = [process.env.PYTHON_BIN, "python", "python3"].filter(
+  (candidate): candidate is string => Boolean(candidate && candidate.trim().length > 0),
+);
+
+async function ensureTmpDir(): Promise<void> {
+  await mkdir(TMP_DIR, { recursive: true });
+}
+
+async function saveUploadedFile(file: File): Promise<{ inputPath: string; baseName: string }> {
+  await ensureTmpDir();
+  const bytes = new Uint8Array(await file.arrayBuffer());
+  const baseName = `${randomUUID()}-${file.name}`;
+  const inputPath = path.join(TMP_DIR, baseName);
+  await writeFile(inputPath, bytes);
+  return { inputPath, baseName };
+}
+
+function spawnPythonProcess(command: string, args: string[]): Promise<{ stdout: string; stderr: string; code: number }> {
+  return new Promise((resolve, reject) => {
+    const python = spawn(command, args, {
+      cwd: PROJECT_ROOT,
+      env: {
+        ...process.env,
+        PYTHONUNBUFFERED: "1",
+      },
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    python.stdout.on("data", (data) => {
+      stdout += data.toString();
+    });
+
+    python.stderr.on("data", (data) => {
+      stderr += data.toString();
+    });
+
+    python.on("error", (error) => {
+      reject(error);
+    });
+
+    python.on("close", (code) => {
+      resolve({ stdout, stderr, code: code ?? 1 });
+    });
+  });
+}
+
+async function runPythonMapping(
+  inputPath: string,
+  outputDir: string,
+  outputName?: string,
+): Promise<{ stdout: string; stderr: string; code: number }> {
+  const args = outputName
+    ? [PYTHON_MAPPER, inputPath, outputDir, outputName]
+    : [PYTHON_MAPPER, inputPath, outputDir];
+
+  let lastError: NodeJS.ErrnoException | null = null;
+
+  for (const command of PYTHON_CANDIDATES) {
+    try {
+      return await spawnPythonProcess(command, args);
+    } catch (error) {
+      if (
+        typeof error === "object" &&
+        error !== null &&
+        "code" in error &&
+        (error as NodeJS.ErrnoException).code === "ENOENT"
+      ) {
+        lastError = error as NodeJS.ErrnoException;
+        continue;
+      }
+      throw error;
+    }
+  }
+
+  if (lastError) {
+    throw lastError;
+  }
+
+  throw Object.assign(new Error("Unable to locate a Python interpreter."), { code: "ENOENT" });
+}
+
+function computeOutputName(originalName: string): string {
+  const trimmed = originalName.trim();
+  const base =
+    trimmed.toLowerCase().endsWith(".xlsx") || trimmed.toLowerCase().endsWith(".xlsm")
+      ? trimmed.replace(/\.(xlsx|xlsm)$/i, "")
+      : trimmed || "mapped-file";
+  return `${base}_mapping.xlsx`;
+}
+
+function parseResultName(stdout: string): string | null {
+  const lines = stdout.split(/\r?\n/);
+  for (const line of lines) {
+    if (line.startsWith("RESULT:")) {
+      const candidate = line.slice("RESULT:".length).trim();
+      if (candidate.length > 0) {
+        return candidate;
+      }
+    }
+  }
+  return null;
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  try {
+    const formData = await req.formData();
+    const file = formData.get("file");
+
+    if (!(file instanceof File)) {
+      return new NextResponse("Aucun fichier reçu", { status: 400 });
+    }
+
+    const { inputPath } = await saveUploadedFile(file);
+    const cleanupTargets = new Set<string>([inputPath]);
+
+    const requestedName = computeOutputName(file.name);
+    const runtimeName = `${randomUUID()}-${requestedName}`;
+
+    try {
+      let result;
+      try {
+        result = await runPythonMapping(inputPath, TMP_DIR, runtimeName);
+      } catch (error) {
+        console.error("Failed to start Python mapping", error);
+        const code =
+          typeof error === "object" && error !== null && "code" in error
+            ? (error as NodeJS.ErrnoException).code
+            : undefined;
+        const message =
+          code === "ENOENT"
+            ? "Python n'est pas disponible sur le serveur de mapping."
+            : "Échec lors du lancement du moteur Python.";
+        return NextResponse.json({ success: false, message }, { status: 500 });
+      }
+
+      if (result.code !== 0) {
+        const message = result.stderr || result.stdout || "La génération du fichier a échoué";
+        return NextResponse.json({ success: false, message }, { status: 500 });
+      }
+
+      const generatedName = parseResultName(result.stdout) ?? runtimeName;
+
+      return NextResponse.json({
+        success: true,
+        message: "Mapping terminé. Fichier disponible.",
+        downloadUrl: `/api/reports/${encodeURIComponent(generatedName)}`,
+        originalName: file.name,
+      });
+    } finally {
+      await Promise.all(
+        Array.from(cleanupTargets, (target) =>
+          rm(target, { force: true }).catch(() => undefined),
+        ),
+      );
+    }
+  } catch (error) {
+    console.error(error);
+    return new NextResponse("Erreur interne du serveur", { status: 500 });
+  }
+}

--- a/frontend/app/mapping/page.tsx
+++ b/frontend/app/mapping/page.tsx
@@ -1,0 +1,244 @@
+"use client";
+
+import Link from "next/link";
+import { useRef, useState, type ChangeEvent } from "react";
+
+import { useLanguage } from "../../components/language-provider";
+
+type StatusState =
+  | { type: "idle" }
+  | { type: "ready"; filename: string }
+  | { type: "processing"; filename: string }
+  | { type: "success"; filename: string; downloadUrl: string; originalName: string }
+  | { type: "error"; message: string };
+
+function formatFileSize(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) {
+    return "0 B";
+  }
+  const units = ["B", "KB", "MB", "GB"];
+  const index = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+  const value = bytes / 1024 ** index;
+  return `${value.toFixed(value >= 10 || index === 0 ? 0 : 1)} ${units[index]}`;
+}
+
+export default function MappingPage() {
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [file, setFile] = useState<File | null>(null);
+  const [status, setStatus] = useState<StatusState>({ type: "idle" });
+
+  const { content } = useLanguage();
+  const { mapping, common } = content;
+
+  const statusMessage = (() => {
+    switch (status.type) {
+      case "idle":
+        return mapping.status.idle;
+      case "ready":
+        return mapping.status.ready(status.filename);
+      case "processing":
+        return mapping.status.processing(status.filename);
+      case "success":
+        return mapping.status.success(status.originalName);
+      case "error":
+        return mapping.status.error(status.message);
+      default:
+        return mapping.status.idle;
+    }
+  })();
+
+  function openFileDialog() {
+    fileInputRef.current?.click();
+  }
+
+  function resetSelection() {
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
+    setFile(null);
+    setStatus({ type: "idle" });
+  }
+
+  function handleFileChange(event: ChangeEvent<HTMLInputElement>) {
+    const selected = event.target.files?.[0] ?? null;
+    if (!selected) {
+      resetSelection();
+      return;
+    }
+    setFile(selected);
+    setStatus({ type: "ready", filename: selected.name });
+  }
+
+  async function handleSubmit() {
+    if (!file || status.type === "processing") {
+      return;
+    }
+
+    setStatus({ type: "processing", filename: file.name });
+
+    const formData = new FormData();
+    formData.append("file", file);
+
+    try {
+      const response = await fetch("/api/mapping", {
+        method: "POST",
+        body: formData,
+      });
+
+      const payload = await response.json().catch(() => null);
+
+      if (!response.ok || !payload || payload.success !== true || typeof payload.downloadUrl !== "string") {
+        const message =
+          typeof payload?.message === "string" && payload.message.trim().length > 0
+            ? payload.message
+            : mapping.status.genericError;
+        setStatus({ type: "error", message });
+        return;
+      }
+
+      const originalName =
+        typeof payload.originalName === "string" && payload.originalName.trim().length > 0
+          ? payload.originalName
+          : file.name;
+
+      setStatus({
+        type: "success",
+        filename: file.name,
+        downloadUrl: payload.downloadUrl,
+        originalName,
+      });
+    } catch (error) {
+      console.error("Failed to launch mapping", error);
+      setStatus({ type: "error", message: mapping.status.networkError });
+    }
+  }
+
+  const isProcessing = status.type === "processing";
+  const canLaunch = Boolean(file) && !isProcessing;
+  const downloadUrl = status.type === "success" ? status.downloadUrl : null;
+
+  return (
+    <main className="min-h-screen bg-slate-50 p-6 transition-colors duration-300 dark:bg-slate-950 md:p-10">
+      <div className="mx-auto flex max-w-3xl flex-col gap-10">
+        <div>
+          <Link
+            href="/"
+            className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-700 shadow-sm transition hover:bg-slate-100 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-200 dark:hover:bg-slate-800"
+          >
+            <span aria-hidden>←</span>
+            {common.backToHome}
+          </Link>
+        </div>
+
+        <section className="rounded-3xl border border-slate-200 bg-white p-8 shadow-xl dark:border-slate-800 dark:bg-slate-900">
+          <div className="space-y-6">
+            <header className="space-y-4">
+              <p className="text-xs font-semibold uppercase tracking-[0.3em] text-emerald-500">
+                {mapping.hero.badge}
+              </p>
+              <h1 className="text-3xl font-semibold text-slate-900 dark:text-white">
+                {mapping.hero.title}
+              </h1>
+              <p className="text-base leading-relaxed text-slate-600 dark:text-slate-300">
+                {mapping.hero.description}
+              </p>
+            </header>
+
+            <div className="rounded-2xl border-2 border-dashed border-slate-300 bg-slate-50/60 p-6 text-center dark:border-slate-700 dark:bg-slate-950/40">
+              {file ? (
+                <div className="space-y-2">
+                  <p className="text-base font-medium text-slate-800 dark:text-slate-100">{file.name}</p>
+                  <p className="text-sm text-slate-500 dark:text-slate-400">
+                    {formatFileSize(file.size)} · {file.type || mapping.hero.unknownType}
+                  </p>
+                </div>
+              ) : (
+                <div className="space-y-2">
+                  <p className="text-base font-medium text-slate-800 dark:text-slate-100">
+                    {mapping.hero.uploadLabel}
+                  </p>
+                  <p className="text-sm text-slate-500 dark:text-slate-400">
+                    {mapping.hero.uploadHint}
+                  </p>
+                </div>
+              )}
+
+              <div className="mt-5 flex flex-wrap items-center justify-center gap-3">
+                <button
+                  type="button"
+                  onClick={openFileDialog}
+                  className="inline-flex items-center gap-2 rounded-full bg-emerald-600 px-5 py-2 text-sm font-semibold text-white shadow-lg transition hover:bg-emerald-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 dark:ring-offset-slate-900"
+                >
+                  {file ? mapping.actions.changeFile : mapping.actions.selectFile}
+                </button>
+                {file ? (
+                  <button
+                    type="button"
+                    onClick={resetSelection}
+                    className="inline-flex items-center gap-2 rounded-full border border-slate-300 px-4 py-2 text-sm font-medium text-slate-600 transition hover:bg-slate-100 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800"
+                  >
+                    {mapping.actions.removeFile}
+                  </button>
+                ) : null}
+              </div>
+            </div>
+
+            <div className="flex flex-wrap items-center gap-3">
+              <button
+                type="button"
+                onClick={handleSubmit}
+                disabled={!canLaunch}
+                className="inline-flex items-center gap-2 rounded-full bg-slate-900 px-5 py-2 text-sm font-semibold text-white shadow-lg transition hover:bg-slate-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-white/90"
+              >
+                {isProcessing ? mapping.actions.processing : mapping.actions.start}
+              </button>
+
+              {downloadUrl ? (
+                <a
+                  href={downloadUrl}
+                  className="inline-flex items-center gap-2 rounded-full border border-emerald-500 px-5 py-2 text-sm font-semibold text-emerald-600 transition hover:bg-emerald-50 dark:border-emerald-400 dark:text-emerald-300 dark:hover:bg-emerald-400/10"
+                >
+                  {mapping.actions.download}
+                </a>
+              ) : null}
+            </div>
+
+            <p
+              className={`rounded-2xl border px-4 py-3 text-sm leading-relaxed ${
+                status.type === "error"
+                  ? "border-red-200 bg-red-50 text-red-700 dark:border-red-900/60 dark:bg-red-900/40 dark:text-red-200"
+                  : "border-slate-200 bg-slate-100 text-slate-700 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-200"
+              }`}
+            >
+              {statusMessage}
+            </p>
+          </div>
+        </section>
+
+        <section className="rounded-3xl border border-slate-200 bg-white p-8 shadow-lg dark:border-slate-800 dark:bg-slate-900">
+          <h2 className="text-lg font-semibold text-slate-900 dark:text-white">
+            {mapping.tips.title}
+          </h2>
+          <ul className="mt-4 space-y-3 text-sm leading-relaxed text-slate-600 dark:text-slate-300">
+            {mapping.tips.items.map((tip) => (
+              <li key={tip} className="flex items-start gap-3">
+                <span className="mt-1 inline-flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-emerald-100 text-xs font-semibold text-emerald-700 dark:bg-emerald-900/50 dark:text-emerald-200">
+                  ✓
+                </span>
+                <span>{tip}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      </div>
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept=".xlsx,.xlsm"
+        className="hidden"
+        onChange={handleFileChange}
+      />
+    </main>
+  );
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,707 +1,88 @@
-﻿"use client";
+"use client";
 
-import { useMemo, useRef, useState } from "react";
-import * as XLSX from "xlsx";
+import Link from "next/link";
 
 import { useLanguage } from "../components/language-provider";
-import type { Translation } from "../components/language-provider";
 
-const truthyValues = new Set(["true", "1", "yes", "oui", "y", "x"]);
-
-type AllowedType = "list" | "instruction";
-
-type RuleRow = {
-  id: string;
-  field: string;
-  checked: boolean;
-  required: boolean;
-  minLength?: number;
-  maxLength?: number;
-  allowedType: AllowedType;
-  allowedValues: string[];
-  allowedInstruction: string;
-  pattern?: string;
-  customRule?: string;
-};
-
-type RulePayload = {
-  field: string;
-  checked: boolean;
-  required: boolean;
-  minLength: number | null;
-  maxLength: number | null;
-  allowedType: AllowedType;
-  allowedValues: string[];
-  allowedInstruction: string;
-  pattern: string;
-  customRule: string;
-};
-
- type StatusState =
-   | { type: "default" }
-   | { type: "awaiting" }
-   | { type: "newRule" }
-   | { type: "rulesUpdated" }
-   | { type: "analyzing"; filename: string }
-   | { type: "analyzed" }
-   | { type: "importedTemplate" }
-   | { type: "importedNoHeaders" }
-   | { type: "readError" }
-   | { type: "validating" }
-   | { type: "validationError"; message: string }
-   | { type: "validationFailed" }
-   | { type: "validationSuccess" }
-   | { type: "networkError" }
-   | { type: "custom"; message: string };
- 
- async function readErrorMessage(response: Response): Promise<string | null> {
-   const contentType = response.headers.get("content-type") ?? "";
-   if (contentType.includes("application/json")) {
-     try {
-       const data = await response.clone().json();
-       const message = typeof data?.message === "string" ? data.message.trim() : "";
-       if (message.length > 0) {
-         return message;
-       }
-     } catch {
-       // ignore JSON parsing errors, we will fallback to text
-     }
-   }
- 
-   try {
-     const text = await response.text();
-     const trimmed = text.trim();
-     return trimmed.length > 0 ? trimmed : null;
-   } catch {
-     return null;
-   }
- }
- 
- function resolveStatusMessage(
-  status: StatusState,
-  statuses: Translation["statuses"],
-): string {
-  switch (status.type) {
-    case "default":
-      return statuses.default;
-    case "awaiting":
-      return statuses.awaiting;
-    case "newRule":
-      return statuses.newRule;
-    case "rulesUpdated":
-      return statuses.rulesUpdated;
-    case "analyzing":
-      return statuses.analyzing(status.filename);
-    case "analyzed":
-      return statuses.analyzed;
-    case "importedTemplate":
-      return statuses.importedTemplate;
-    case "importedNoHeaders":
-      return statuses.importedNoHeaders;
-    case "readError":
-      return statuses.readError;
-    case "validating":
-      return statuses.validating;
-    case "validationError":
-      return statuses.validationError(status.message);
-    case "validationFailed":
-      return statuses.validationFailed;
-    case "validationSuccess":
-      return statuses.validationSuccess;
-    case "networkError":
-      return statuses.networkError;
-    case "custom":
-      return status.message;
-    default: {
-      const exhaustiveCheck: never = status;
-      return exhaustiveCheck;
-    }
-  }
-}
-
-function createId(): string {
-  if (typeof globalThis.crypto?.randomUUID === "function") {
-    return globalThis.crypto.randomUUID();
-  }
-  return `rule-${Date.now()}-${Math.random().toString(16).slice(2)}`;
-}
-
-function toBoolean(value: unknown): boolean {
-  if (typeof value === "boolean") return value;
-  if (value === undefined || value === null) return false;
-  return truthyValues.has(String(value).trim().toLowerCase());
-}
-
-function toNumber(value: unknown): number | undefined {
-  if (value === undefined || value === null || value === "") return undefined;
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : undefined;
-}
-
-function parseNumberInput(value: string): number | undefined {
-  const trimmed = value.trim();
-  if (!trimmed) {
-    return undefined;
-  }
-  const parsed = Number(trimmed);
-  return Number.isFinite(parsed) ? parsed : undefined;
-}
-
-function mapRowsToRules(jsonRows: Record<string, unknown>[]): RuleRow[] {
-  return jsonRows.reduce<RuleRow[]>((acc, row) => {
-    const fieldValue = row["Field"];
-    const field = typeof fieldValue === "string" ? fieldValue.trim() : String(fieldValue ?? "").trim();
-    if (!field) {
-      return acc;
-    }
-
-    const allowedValue = row["AllowedValues"];
-    const allowedRaw = typeof allowedValue === "string" ? allowedValue.trim() : "";
-    let allowedValues: string[] = [];
-    let allowedInstruction = "";
-    if (allowedRaw) {
-      if (allowedRaw.toUpperCase().startsWith("VALUE=")) {
-        allowedValues = allowedRaw
-          .slice(6)
-          .split(";")
-          .map((entry) => entry.trim())
-          .filter((entry) => entry.length > 0);
-      } else {
-        allowedInstruction = allowedRaw;
-      }
-    }
-
-    const allowedType: AllowedType = allowedValues.length > 0 ? "list" : "instruction";
-
-    const pattern = row["Pattern"] ? String(row["Pattern"]).trim() : "";
-    const customRule = row["CustomRule"] ? String(row["CustomRule"]).trim() : "";
-
-    acc.push({
-      id: createId(),
-      field,
-      checked: toBoolean(row["Checked"]),
-      required: toBoolean(row["Required"]),
-      minLength: toNumber(row["MinLength"]),
-      maxLength: toNumber(row["MaxLength"]),
-      allowedType,
-      allowedValues,
-      allowedInstruction: allowedType === "instruction" ? allowedInstruction : "",
-      pattern: pattern || undefined,
-      customRule: customRule || undefined,
-    });
-
-    return acc;
-  }, []);
-}
-
-function serializeRulesForBackend(rules: RuleRow[]): RulePayload[] {
-  return rules
-    .map((rule) => {
-      const field = rule.field.trim();
-      if (!field) {
-        return null;
-      }
-      const allowedValues =
-        rule.allowedType === "list"
-          ? rule.allowedValues.map((value) => value.trim()).filter((value) => value.length > 0)
-          : [];
-
-      return {
-        field,
-        checked: rule.checked,
-        required: rule.required,
-        minLength: rule.minLength ?? null,
-        maxLength: rule.maxLength ?? null,
-        allowedType: rule.allowedType,
-        allowedValues,
-        allowedInstruction: rule.allowedType === "instruction" ? rule.allowedInstruction.trim() : "",
-        pattern: rule.pattern?.trim() ?? "",
-        customRule: rule.customRule?.trim() ?? "",
-      } satisfies RulePayload;
-    })
-    .filter((value): value is RulePayload => value !== null);
-}
-
-function createRuleFromField(field: string): RuleRow {
-  return {
-    id: createId(),
-    field,
-    checked: true,
-    required: false,
-    minLength: undefined,
-    maxLength: undefined,
-    allowedType: "list",
-    allowedValues: [],
-    allowedInstruction: "",
-    pattern: undefined,
-    customRule: undefined,
-  };
-}
-
-function createEmptyRule(): RuleRow {
-  return createRuleFromField("");
-}
-
-function extractTemplateFields(sheet?: XLSX.WorkSheet): string[] {
-  if (!sheet) {
-    return [];
-  }
-
-  const rows = XLSX.utils.sheet_to_json<unknown[]>(sheet, { header: 1, blankrows: false });
-  if (rows.length === 0) {
-    return [];
-  }
-
-  const headerRow =
-    rows.find((row) =>
-      row.some((cell) => {
-        if (cell === undefined || cell === null) {
-          return false;
-        }
-        return String(cell).trim().length > 0;
-      }),
-    ) ?? [];
-
-  return headerRow
-    .map((cell) => (cell === undefined || cell === null ? "" : String(cell).trim()))
-    .filter((value) => value.length > 0);
-}
-
-export default function HomePage() {
+export default function LandingPage() {
   const { content } = useLanguage();
-  const { hero, rules: rulesText, footer, statuses } = content;
-
-  const [rules, setRules] = useState<RuleRow[]>([]);
-  const [file, setFile] = useState<File | null>(null);
-  const [status, setStatus] = useState<StatusState>({ type: "default" });
-  const [reportUrl, setReportUrl] = useState<string | null>(null);
-  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
-  const [rulesEdited, setRulesEdited] = useState<boolean>(false);
-  const fileInputRef = useRef<HTMLInputElement | null>(null);
-
-  const statusMessage = resolveStatusMessage(status, statuses);
-
-  const hasMissingField = useMemo(() => rules.some((rule) => !rule.field.trim()), [rules]);
-
-  function markRulesEdited(nextStatus: StatusState = { type: "awaiting" }) {
-    setRulesEdited(true);
-    if (!isSubmitting) {
-      setStatus(nextStatus);
-    }
-  }
-
-  function resetSelection(nextStatus: StatusState = { type: "default" }) {
-    if (fileInputRef.current) {
-      fileInputRef.current.value = "";
-    }
-    setFile(null);
-    setRules([]);
-    setRulesEdited(false);
-    setReportUrl(null);
-    setStatus(nextStatus);
-  }
-
-  function updateRule(id: string, updates: Partial<RuleRow>) {
-    setRules((prev) =>
-      prev.map((rule) => {
-        if (rule.id !== id) return rule;
-        const next: RuleRow = { ...rule, ...updates };
-        if (updates.allowedType) {
-          if (updates.allowedType === "list") {
-            next.allowedInstruction = "";
-          } else {
-            next.allowedValues = [];
-          }
-        }
-        if (next.allowedType === "list" && updates.allowedInstruction !== undefined) {
-          next.allowedInstruction = "";
-        }
-        if (next.allowedType === "instruction" && updates.allowedValues !== undefined) {
-          next.allowedValues = [];
-        }
-        return next;
-      }),
-    );
-    markRulesEdited();
-  }
-
-  function addRule() {
-    setRules((prev) => [...prev, createEmptyRule()]);
-    markRulesEdited({ type: "newRule" });
-  }
-
-  function removeRule(id: string) {
-    setRules((prev) => prev.filter((rule) => rule.id !== id));
-    markRulesEdited({ type: "rulesUpdated" });
-  }
-
-  async function handleFileChange(event: React.ChangeEvent<HTMLInputElement>) {
-    const selected = event.target.files?.[0] ?? null;
-
-    if (!selected) {
-      resetSelection();
-      return;
-    }
-
-    setReportUrl(null);
-    setRules([]);
-    setRulesEdited(false);
-    setFile(selected);
-    setStatus({ type: "analyzing", filename: selected.name });
-
-    try {
-      const data = await selected.arrayBuffer();
-      const workbook = XLSX.read(data);
-      const validationSheet = workbook.Sheets["ValidationRules"];
-      const templateSheet = workbook.Sheets["Template"];
-
-      const mappedRules = validationSheet
-        ? mapRowsToRules(
-            XLSX.utils.sheet_to_json<Record<string, unknown>>(validationSheet, {
-              defval: "",
-              blankrows: false,
-            }),
-          )
-        : [];
-
-      if (mappedRules.length > 0) {
-        setRules(mappedRules);
-        setRulesEdited(false);
-        setStatus({ type: "analyzed" });
-        return;
-      }
-
-      const templateFields = extractTemplateFields(templateSheet);
-      if (templateFields.length > 0) {
-        const generatedRules = templateFields.map((field) => createRuleFromField(field));
-        setRules(generatedRules);
-        setRulesEdited(true);
-        setStatus({ type: "importedTemplate" });
-        return;
-      }
-
-      setRules([]);
-      setRulesEdited(false);
-      setStatus({ type: "importedNoHeaders" });
-    } catch (error) {
-      console.error(error);
-      setStatus({ type: "readError" });
-    }
-  }
-
-  async function launchValidation() {
-    if (!file) return;
-    setIsSubmitting(true);
-    setStatus({ type: "validating" });
-    setReportUrl(null);
-
-    try {
-      const formData = new FormData();
-      formData.set("file", file);
-
-      if (rulesEdited) {
-        const payload = serializeRulesForBackend(rules);
-        formData.set("rules", JSON.stringify(payload));
-      }
-
-      const response = await fetch("/api/validate", {
-        method: "POST",
-        body: formData,
-      });
-
-      if (!response.ok) {
-        const message = await readErrorMessage(response);
-        setStatus(
-          message
-            ? { type: "validationError", message }
-            : { type: "validationFailed" },
-        );
-        return;
-      }
-
-      const payload: {
-        success: boolean;
-        message?: string;
-        downloadUrl?: string;
-      } = await response.json();
-
-      if (!payload.success) {
-        setStatus(
-          payload.message
-            ? { type: "custom", message: payload.message }
-            : { type: "validationFailed" },
-        );
-        return;
-      }
-
-      setStatus(
-        payload.message
-          ? { type: "custom", message: payload.message }
-          : { type: "validationSuccess" },
-      );
-      if (payload.downloadUrl) {
-        setReportUrl(payload.downloadUrl);
-      }
-    } catch (error) {
-      console.error(error);
-      setStatus({ type: "networkError" });
-    } finally {
-      setIsSubmitting(false);
-    }
-  }
+  const { home } = content;
 
   return (
-    <main className="min-h-screen bg-slate-50 p-6 transition-colors duration-300 dark:bg-slate-950 md:p-10">
-      <section className="mx-auto flex max-w-5xl flex-col gap-8">
-        <header className="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-100 dark:bg-slate-900 dark:ring-slate-800">
-          <h1 className="text-2xl font-semibold text-slate-900 dark:text-slate-100">{hero.title}</h1>
-          <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">{hero.description}</p>
-          <label className="mt-6 flex cursor-pointer flex-col items-center gap-2 rounded-xl border-2 border-dashed border-slate-300 p-6 text-center transition hover:border-indigo-400 dark:border-slate-600 dark:bg-slate-900/40">
-            <span className="text-base font-medium text-slate-700 dark:text-slate-200">{hero.uploadLabel}</span>
-            <span className="text-sm text-slate-500 dark:text-slate-400">{hero.uploadHint}</span>
-            <input type="file" accept=".xlsx,.xlsm" className="hidden" onChange={handleFileChange} ref={fileInputRef} />
-          </label>
+    <main className="min-h-screen bg-slate-50 px-6 py-16 transition-colors duration-300 dark:bg-slate-950 sm:px-10">
+      <div className="mx-auto flex max-w-5xl flex-col gap-12">
+        <header className="space-y-4 text-center sm:text-left">
+          <p className="text-sm font-medium uppercase tracking-[0.3em] text-slate-500 dark:text-slate-400">
+            {home.badge}
+          </p>
+          <h1 className="text-3xl font-semibold text-slate-900 dark:text-white sm:text-4xl">
+            {home.title}
+          </h1>
+          <p className="max-w-3xl text-base text-slate-600 dark:text-slate-300 sm:text-lg">
+            {home.description}
+          </p>
         </header>
 
-        <article className="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-100 dark:bg-slate-900 dark:ring-slate-800">
-          <header className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-            <div>
-              <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">{rulesText.heading}</h2>
-              <p className="text-sm text-slate-500 dark:text-slate-400">{rulesText.description}</p>
+        <div className="grid gap-6 md:grid-cols-2">
+          <article className="group relative overflow-hidden rounded-2xl border border-slate-200 bg-white p-8 shadow-lg transition hover:-translate-y-1 hover:shadow-xl dark:border-slate-800 dark:bg-slate-900">
+            <div className="absolute inset-0 opacity-0 transition group-hover:opacity-100">
+              <div className="absolute -left-24 -top-24 h-48 w-48 rounded-full bg-blue-100 blur-3xl dark:bg-blue-900/50" />
+              <div className="absolute -bottom-24 -right-16 h-48 w-48 rounded-full bg-cyan-100 blur-3xl dark:bg-cyan-900/50" />
             </div>
-            <div className="flex items-center gap-3">
-              <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-600 dark:bg-slate-800 dark:text-slate-200">
-                {rulesText.countLabel(rules.length)}
-              </span>
-              <button
-                type="button"
-                onClick={addRule}
-                className="inline-flex items-center rounded-lg border border-indigo-600 px-4 py-2 text-sm font-semibold text-indigo-600 transition hover:bg-indigo-50 dark:border-indigo-400 dark:text-indigo-300 dark:hover:bg-indigo-500/10"
-              >
-                {rulesText.addButton}
-              </button>
+            <div className="relative flex h-full flex-col gap-6">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-[0.2em] text-blue-500">
+                  {home.options.review.label}
+                </p>
+                <h2 className="mt-2 text-2xl font-semibold text-slate-900 dark:text-white">
+                  {home.options.review.title}
+                </h2>
+                <p className="mt-3 text-sm leading-relaxed text-slate-600 dark:text-slate-300">
+                  {home.options.review.description}
+                </p>
+              </div>
+              <div className="mt-auto">
+                <Link
+                  href="/review"
+                  className="inline-flex items-center gap-2 rounded-full bg-blue-600 px-5 py-2 text-sm font-semibold text-white shadow-lg transition hover:bg-blue-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-offset-2 dark:ring-offset-slate-950"
+                >
+                  {home.options.review.action}
+                  <span aria-hidden>→</span>
+                </Link>
+              </div>
             </div>
-          </header>
+          </article>
 
-          <div className="mt-6 rounded-xl border border-indigo-100 bg-indigo-50 p-4 text-sm text-indigo-900 dark:border-indigo-900 dark:bg-indigo-950/40 dark:text-indigo-200">
-            <p className="font-medium">{rulesText.tipTitle}</p>
-            <ul className="mt-2 list-disc space-y-1 pl-4">
-              {rulesText.tips.map((tip) => (
-                <li key={tip}>{tip}</li>
-              ))}
-            </ul>
-          </div>
-
-          {rules.length === 0 ? (
-            <div className="mt-6 rounded-xl border border-slate-200 bg-slate-50 p-6 text-center text-sm text-slate-600 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300">
-              <p>{rulesText.emptyState.description}</p>
-              <button
-                type="button"
-                onClick={addRule}
-                className="mt-4 inline-flex items-center rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-700"
-              >
-                {rulesText.emptyState.action}
-              </button>
+          <article className="group relative overflow-hidden rounded-2xl border border-slate-200 bg-white p-8 shadow-lg transition hover:-translate-y-1 hover:shadow-xl dark:border-slate-800 dark:bg-slate-900">
+            <div className="absolute inset-0 opacity-0 transition group-hover:opacity-100">
+              <div className="absolute -left-20 -top-28 h-48 w-48 rounded-full bg-emerald-100 blur-3xl dark:bg-emerald-900/50" />
+              <div className="absolute -bottom-24 -right-16 h-48 w-48 rounded-full bg-lime-100 blur-3xl dark:bg-lime-900/50" />
             </div>
-          ) : (
-            <div className="mt-6 space-y-6">
-              {rules.map((rule) => {
-                const fieldIsEmpty = rule.field.trim().length === 0;
-                return (
-                  <div key={rule.id} className="rounded-xl border border-slate-200 shadow-sm dark:border-slate-700 dark:bg-slate-900">
-                    <div className="flex flex-col gap-4 border-b border-slate-100 bg-slate-50 p-5 dark:border-slate-800 dark:bg-slate-950 md:flex-row md:items-end">
-                    <div className="flex-1">
-                        <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">{rulesText.field.label}</label>
-                        <input
-                          type="text"
-                          value={rule.field}
-                          onChange={(event) => updateRule(rule.id, { field: event.target.value })}
-                          className={`mt-2 w-full rounded-lg border px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:bg-slate-950 dark:text-slate-100 dark:placeholder-slate-400 ${fieldIsEmpty ? "border-rose-400 dark:border-rose-400" : "border-slate-200 dark:border-slate-700"}`}
-                          placeholder={rulesText.field.placeholder}
-                        />
-                        {fieldIsEmpty && (
-                          <p className="mt-1 text-xs text-rose-600 dark:text-rose-400">{rulesText.field.error}</p>
-                        )}
-                      </div>
-                      <button
-                        type="button"
-                        onClick={() => removeRule(rule.id)}
-                        className="inline-flex items-center justify-center rounded-lg border border-rose-200 px-3 py-2 text-xs font-semibold text-rose-600 transition hover:bg-rose-50 dark:border-rose-400/40 dark:text-rose-300 dark:hover:bg-rose-500/10"
-                      >
-                        {rulesText.removeButton}
-                      </button>
-                    </div>
-
-                    <div className="grid gap-6 p-5 md:grid-cols-2">
-                      <div className="space-y-5">
-                        <fieldset className="grid grid-cols-2 gap-3 text-sm text-slate-700 dark:text-slate-200">
-                          <label className="flex items-center gap-2">
-                            <input
-                              type="checkbox"
-                              checked={rule.checked}
-                              onChange={(event) => updateRule(rule.id, { checked: event.target.checked })}
-                              className="h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500 dark:border-slate-600 dark:bg-slate-900 dark:text-indigo-400 dark:focus:ring-indigo-400"
-                            />
-                            {rulesText.toggles.checked}
-                          </label>
-                          <label className="flex items-center gap-2">
-                            <input
-                              type="checkbox"
-                              checked={rule.required}
-                              onChange={(event) => updateRule(rule.id, { required: event.target.checked })}
-                              className="h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500 dark:border-slate-600 dark:bg-slate-900 dark:text-indigo-400 dark:focus:ring-indigo-400"
-                            />
-                            {rulesText.toggles.required}
-                          </label>
-                        </fieldset>
-
-                        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-                          <div>
-                            <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">{rulesText.length.minLabel}</label>
-                            <input
-                              type="number"
-                              value={rule.minLength ?? ""}
-                              onChange={(event) => updateRule(rule.id, { minLength: parseNumberInput(event.target.value) })}
-                              className="mt-2 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:placeholder-slate-400"
-                              placeholder={rulesText.length.placeholder}
-                            />
-                          </div>
-                          <div>
-                            <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">{rulesText.length.maxLabel}</label>
-                            <input
-                              type="number"
-                              value={rule.maxLength ?? ""}
-                              onChange={(event) => updateRule(rule.id, { maxLength: parseNumberInput(event.target.value) })}
-                              className="mt-2 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:placeholder-slate-400"
-                              placeholder={rulesText.length.placeholder}
-                            />
-                          </div>
-                        </div>
-
-                        <div>
-                          <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">{rulesText.pattern.label}</label>
-                          <input
-                            type="text"
-                            value={rule.pattern ?? ""}
-                            onChange={(event) => updateRule(rule.id, { pattern: event.target.value || undefined })}
-                            className="mt-2 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:placeholder-slate-400"
-                            placeholder={rulesText.pattern.placeholder}
-                          />
-                        </div>
-
-                        <div>
-                          <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">{rulesText.customRule.label}</label>
-                          <input
-                            type="text"
-                            value={rule.customRule ?? ""}
-                            onChange={(event) => updateRule(rule.id, { customRule: event.target.value || undefined })}
-                            className="mt-2 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:placeholder-slate-400"
-                            placeholder={rulesText.customRule.placeholder}
-                          />
-                        </div>
-                      </div>
-
-                      <div className="space-y-5">
-                        <div>
-                          <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
-                            {rulesText.allowed.label}
-                          </label>
-                          <select
-                            value={rule.allowedType}
-                            onChange={(event) => updateRule(rule.id, { allowedType: event.target.value as AllowedType })}
-                            className="mt-2 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100"
-                          >
-                            <option value="list">{rulesText.allowed.options.list}</option>
-                            <option value="instruction">{rulesText.allowed.options.instruction}</option>
-                          </select>
-                        </div>
-
-                        {rule.allowedType === "list" ? (
-                          <div>
-                            <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
-                              {rulesText.allowed.valuesLabel}
-                            </label>
-                            <textarea
-                              value={rule.allowedValues.join("\n")}
-                              onChange={(event) =>
-                                updateRule(rule.id, {
-                                  allowedValues: event.target.value
-                                    .split(/\r?\n/)
-                                    .map((value) => value.trim())
-                                    .filter((value) => value.length > 0),
-                                })
-                              }
-                              className="mt-2 h-28 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:placeholder-slate-400"
-                              placeholder={rulesText.allowed.valuesPlaceholder}
-                            />
-                            <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">{rulesText.allowed.valuesHint}</p>
-                            {rule.allowedValues.length > 0 && (
-                              <div className="mt-3 flex flex-wrap gap-2">
-                                {rule.allowedValues.map((value) => (
-                                  <span
-                                    key={`${rule.id}-${value}`}
-                                    className="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-700 dark:bg-slate-800 dark:text-slate-200"
-                                  >
-                                    {value}
-                                  </span>
-                                ))}
-                              </div>
-                            )}
-                          </div>
-                        ) : (
-                          <div>
-                            <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
-                              {rulesText.allowed.instructionLabel}
-                            </label>
-                            <textarea
-                              value={rule.allowedInstruction}
-                              onChange={(event) => updateRule(rule.id, { allowedInstruction: event.target.value })}
-                              className="mt-2 h-28 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:placeholder-slate-400"
-                              placeholder={rulesText.allowed.instructionPlaceholder}
-                            />
-                            <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">{rulesText.allowed.instructionHint}</p>
-                          </div>
-                        )}
-                      </div>
-                    </div>
-                  </div>
-                );
-              })}
+            <div className="relative flex h-full flex-col gap-6">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-[0.2em] text-emerald-500">
+                  {home.options.mapping.label}
+                </p>
+                <h2 className="mt-2 text-2xl font-semibold text-slate-900 dark:text-white">
+                  {home.options.mapping.title}
+                </h2>
+                <p className="mt-3 text-sm leading-relaxed text-slate-600 dark:text-slate-300">
+                  {home.options.mapping.description}
+                </p>
+              </div>
+              <div className="mt-auto">
+                <Link
+                  href="/mapping"
+                  className="inline-flex items-center gap-2 rounded-full bg-emerald-600 px-5 py-2 text-sm font-semibold text-white shadow-lg transition hover:bg-emerald-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 dark:ring-offset-slate-950"
+                >
+                  {home.options.mapping.action}
+                  <span aria-hidden>→</span>
+                </Link>
+              </div>
             </div>
-          )}
-        </article>
-
-        <footer className="flex flex-col gap-4 rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-100 dark:bg-slate-900 dark:ring-slate-800 md:flex-row md:items-center md:justify-between">
-          <p className="text-sm text-slate-600 dark:text-slate-300">{statusMessage}</p>
-          <div className="flex flex-wrap gap-3">
-            <button
-              type="button"
-              onClick={() => resetSelection()}
-              disabled={!file || isSubmitting}
-              className="rounded-lg border border-rose-500 px-4 py-2 text-sm font-semibold text-rose-600 shadow-sm transition disabled:cursor-not-allowed disabled:opacity-50 dark:border-rose-400 dark:text-rose-300"
-            >
-              {footer.removeFile}
-            </button>
-            <button
-              type="button"
-              disabled={!file || isSubmitting || hasMissingField}
-              onClick={launchValidation}
-              className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow transition disabled:cursor-not-allowed disabled:bg-slate-300 dark:disabled:bg-slate-700"
-            >
-              {isSubmitting ? footer.validating : footer.startValidation}
-            </button>
-            {reportUrl && (
-              <a
-                href={reportUrl}
-                className="rounded-lg border border-indigo-600 px-4 py-2 text-sm font-semibold text-indigo-600 transition hover:bg-indigo-50 dark:border-indigo-400 dark:text-indigo-300 dark:hover:bg-indigo-500/10"
-              >
-                {footer.downloadReport}
-              </a>
-            )}
-          </div>
-        </footer>
-      </section>
+          </article>
+        </div>
+      </div>
     </main>
   );
 }
-

--- a/frontend/app/review/page.tsx
+++ b/frontend/app/review/page.tsx
@@ -1,0 +1,717 @@
+﻿"use client";
+
+import Link from "next/link";
+import { useMemo, useRef, useState } from "react";
+import * as XLSX from "xlsx";
+
+import { useLanguage } from "../../components/language-provider";
+import type { Translation } from "../../components/language-provider";
+
+const truthyValues = new Set(["true", "1", "yes", "oui", "y", "x"]);
+
+type AllowedType = "list" | "instruction";
+
+type RuleRow = {
+  id: string;
+  field: string;
+  checked: boolean;
+  required: boolean;
+  minLength?: number;
+  maxLength?: number;
+  allowedType: AllowedType;
+  allowedValues: string[];
+  allowedInstruction: string;
+  pattern?: string;
+  customRule?: string;
+};
+
+type RulePayload = {
+  field: string;
+  checked: boolean;
+  required: boolean;
+  minLength: number | null;
+  maxLength: number | null;
+  allowedType: AllowedType;
+  allowedValues: string[];
+  allowedInstruction: string;
+  pattern: string;
+  customRule: string;
+};
+
+ type StatusState =
+   | { type: "default" }
+   | { type: "awaiting" }
+   | { type: "newRule" }
+   | { type: "rulesUpdated" }
+   | { type: "analyzing"; filename: string }
+   | { type: "analyzed" }
+   | { type: "importedTemplate" }
+   | { type: "importedNoHeaders" }
+   | { type: "readError" }
+   | { type: "validating" }
+   | { type: "validationError"; message: string }
+   | { type: "validationFailed" }
+   | { type: "validationSuccess" }
+   | { type: "networkError" }
+   | { type: "custom"; message: string };
+ 
+ async function readErrorMessage(response: Response): Promise<string | null> {
+   const contentType = response.headers.get("content-type") ?? "";
+   if (contentType.includes("application/json")) {
+     try {
+       const data = await response.clone().json();
+       const message = typeof data?.message === "string" ? data.message.trim() : "";
+       if (message.length > 0) {
+         return message;
+       }
+     } catch {
+       // ignore JSON parsing errors, we will fallback to text
+     }
+   }
+ 
+   try {
+     const text = await response.text();
+     const trimmed = text.trim();
+     return trimmed.length > 0 ? trimmed : null;
+   } catch {
+     return null;
+   }
+ }
+ 
+ function resolveStatusMessage(
+  status: StatusState,
+  statuses: Translation["statuses"],
+): string {
+  switch (status.type) {
+    case "default":
+      return statuses.default;
+    case "awaiting":
+      return statuses.awaiting;
+    case "newRule":
+      return statuses.newRule;
+    case "rulesUpdated":
+      return statuses.rulesUpdated;
+    case "analyzing":
+      return statuses.analyzing(status.filename);
+    case "analyzed":
+      return statuses.analyzed;
+    case "importedTemplate":
+      return statuses.importedTemplate;
+    case "importedNoHeaders":
+      return statuses.importedNoHeaders;
+    case "readError":
+      return statuses.readError;
+    case "validating":
+      return statuses.validating;
+    case "validationError":
+      return statuses.validationError(status.message);
+    case "validationFailed":
+      return statuses.validationFailed;
+    case "validationSuccess":
+      return statuses.validationSuccess;
+    case "networkError":
+      return statuses.networkError;
+    case "custom":
+      return status.message;
+    default: {
+      const exhaustiveCheck: never = status;
+      return exhaustiveCheck;
+    }
+  }
+}
+
+function createId(): string {
+  if (typeof globalThis.crypto?.randomUUID === "function") {
+    return globalThis.crypto.randomUUID();
+  }
+  return `rule-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+function toBoolean(value: unknown): boolean {
+  if (typeof value === "boolean") return value;
+  if (value === undefined || value === null) return false;
+  return truthyValues.has(String(value).trim().toLowerCase());
+}
+
+function toNumber(value: unknown): number | undefined {
+  if (value === undefined || value === null || value === "") return undefined;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function parseNumberInput(value: string): number | undefined {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const parsed = Number(trimmed);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function mapRowsToRules(jsonRows: Record<string, unknown>[]): RuleRow[] {
+  return jsonRows.reduce<RuleRow[]>((acc, row) => {
+    const fieldValue = row["Field"];
+    const field = typeof fieldValue === "string" ? fieldValue.trim() : String(fieldValue ?? "").trim();
+    if (!field) {
+      return acc;
+    }
+
+    const allowedValue = row["AllowedValues"];
+    const allowedRaw = typeof allowedValue === "string" ? allowedValue.trim() : "";
+    let allowedValues: string[] = [];
+    let allowedInstruction = "";
+    if (allowedRaw) {
+      if (allowedRaw.toUpperCase().startsWith("VALUE=")) {
+        allowedValues = allowedRaw
+          .slice(6)
+          .split(";")
+          .map((entry) => entry.trim())
+          .filter((entry) => entry.length > 0);
+      } else {
+        allowedInstruction = allowedRaw;
+      }
+    }
+
+    const allowedType: AllowedType = allowedValues.length > 0 ? "list" : "instruction";
+
+    const pattern = row["Pattern"] ? String(row["Pattern"]).trim() : "";
+    const customRule = row["CustomRule"] ? String(row["CustomRule"]).trim() : "";
+
+    acc.push({
+      id: createId(),
+      field,
+      checked: toBoolean(row["Checked"]),
+      required: toBoolean(row["Required"]),
+      minLength: toNumber(row["MinLength"]),
+      maxLength: toNumber(row["MaxLength"]),
+      allowedType,
+      allowedValues,
+      allowedInstruction: allowedType === "instruction" ? allowedInstruction : "",
+      pattern: pattern || undefined,
+      customRule: customRule || undefined,
+    });
+
+    return acc;
+  }, []);
+}
+
+function serializeRulesForBackend(rules: RuleRow[]): RulePayload[] {
+  return rules
+    .map((rule) => {
+      const field = rule.field.trim();
+      if (!field) {
+        return null;
+      }
+      const allowedValues =
+        rule.allowedType === "list"
+          ? rule.allowedValues.map((value) => value.trim()).filter((value) => value.length > 0)
+          : [];
+
+      return {
+        field,
+        checked: rule.checked,
+        required: rule.required,
+        minLength: rule.minLength ?? null,
+        maxLength: rule.maxLength ?? null,
+        allowedType: rule.allowedType,
+        allowedValues,
+        allowedInstruction: rule.allowedType === "instruction" ? rule.allowedInstruction.trim() : "",
+        pattern: rule.pattern?.trim() ?? "",
+        customRule: rule.customRule?.trim() ?? "",
+      } satisfies RulePayload;
+    })
+    .filter((value): value is RulePayload => value !== null);
+}
+
+function createRuleFromField(field: string): RuleRow {
+  return {
+    id: createId(),
+    field,
+    checked: true,
+    required: false,
+    minLength: undefined,
+    maxLength: undefined,
+    allowedType: "list",
+    allowedValues: [],
+    allowedInstruction: "",
+    pattern: undefined,
+    customRule: undefined,
+  };
+}
+
+function createEmptyRule(): RuleRow {
+  return createRuleFromField("");
+}
+
+function extractTemplateFields(sheet?: XLSX.WorkSheet): string[] {
+  if (!sheet) {
+    return [];
+  }
+
+  const rows = XLSX.utils.sheet_to_json<unknown[]>(sheet, { header: 1, blankrows: false });
+  if (rows.length === 0) {
+    return [];
+  }
+
+  const headerRow =
+    rows.find((row) =>
+      row.some((cell) => {
+        if (cell === undefined || cell === null) {
+          return false;
+        }
+        return String(cell).trim().length > 0;
+      }),
+    ) ?? [];
+
+  return headerRow
+    .map((cell) => (cell === undefined || cell === null ? "" : String(cell).trim()))
+    .filter((value) => value.length > 0);
+}
+
+export default function HomePage() {
+  const { content } = useLanguage();
+  const { hero, rules: rulesText, footer, statuses, common } = content;
+
+  const [rules, setRules] = useState<RuleRow[]>([]);
+  const [file, setFile] = useState<File | null>(null);
+  const [status, setStatus] = useState<StatusState>({ type: "default" });
+  const [reportUrl, setReportUrl] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
+  const [rulesEdited, setRulesEdited] = useState<boolean>(false);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  const statusMessage = resolveStatusMessage(status, statuses);
+
+  const hasMissingField = useMemo(() => rules.some((rule) => !rule.field.trim()), [rules]);
+
+  function markRulesEdited(nextStatus: StatusState = { type: "awaiting" }) {
+    setRulesEdited(true);
+    if (!isSubmitting) {
+      setStatus(nextStatus);
+    }
+  }
+
+  function resetSelection(nextStatus: StatusState = { type: "default" }) {
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
+    setFile(null);
+    setRules([]);
+    setRulesEdited(false);
+    setReportUrl(null);
+    setStatus(nextStatus);
+  }
+
+  function updateRule(id: string, updates: Partial<RuleRow>) {
+    setRules((prev) =>
+      prev.map((rule) => {
+        if (rule.id !== id) return rule;
+        const next: RuleRow = { ...rule, ...updates };
+        if (updates.allowedType) {
+          if (updates.allowedType === "list") {
+            next.allowedInstruction = "";
+          } else {
+            next.allowedValues = [];
+          }
+        }
+        if (next.allowedType === "list" && updates.allowedInstruction !== undefined) {
+          next.allowedInstruction = "";
+        }
+        if (next.allowedType === "instruction" && updates.allowedValues !== undefined) {
+          next.allowedValues = [];
+        }
+        return next;
+      }),
+    );
+    markRulesEdited();
+  }
+
+  function addRule() {
+    setRules((prev) => [...prev, createEmptyRule()]);
+    markRulesEdited({ type: "newRule" });
+  }
+
+  function removeRule(id: string) {
+    setRules((prev) => prev.filter((rule) => rule.id !== id));
+    markRulesEdited({ type: "rulesUpdated" });
+  }
+
+  async function handleFileChange(event: React.ChangeEvent<HTMLInputElement>) {
+    const selected = event.target.files?.[0] ?? null;
+
+    if (!selected) {
+      resetSelection();
+      return;
+    }
+
+    setReportUrl(null);
+    setRules([]);
+    setRulesEdited(false);
+    setFile(selected);
+    setStatus({ type: "analyzing", filename: selected.name });
+
+    try {
+      const data = await selected.arrayBuffer();
+      const workbook = XLSX.read(data);
+      const validationSheet = workbook.Sheets["ValidationRules"];
+      const templateSheet = workbook.Sheets["Template"];
+
+      const mappedRules = validationSheet
+        ? mapRowsToRules(
+            XLSX.utils.sheet_to_json<Record<string, unknown>>(validationSheet, {
+              defval: "",
+              blankrows: false,
+            }),
+          )
+        : [];
+
+      if (mappedRules.length > 0) {
+        setRules(mappedRules);
+        setRulesEdited(false);
+        setStatus({ type: "analyzed" });
+        return;
+      }
+
+      const templateFields = extractTemplateFields(templateSheet);
+      if (templateFields.length > 0) {
+        const generatedRules = templateFields.map((field) => createRuleFromField(field));
+        setRules(generatedRules);
+        setRulesEdited(true);
+        setStatus({ type: "importedTemplate" });
+        return;
+      }
+
+      setRules([]);
+      setRulesEdited(false);
+      setStatus({ type: "importedNoHeaders" });
+    } catch (error) {
+      console.error(error);
+      setStatus({ type: "readError" });
+    }
+  }
+
+  async function launchValidation() {
+    if (!file) return;
+    setIsSubmitting(true);
+    setStatus({ type: "validating" });
+    setReportUrl(null);
+
+    try {
+      const formData = new FormData();
+      formData.set("file", file);
+
+      if (rulesEdited) {
+        const payload = serializeRulesForBackend(rules);
+        formData.set("rules", JSON.stringify(payload));
+      }
+
+      const response = await fetch("/api/validate", {
+        method: "POST",
+        body: formData,
+      });
+
+      if (!response.ok) {
+        const message = await readErrorMessage(response);
+        setStatus(
+          message
+            ? { type: "validationError", message }
+            : { type: "validationFailed" },
+        );
+        return;
+      }
+
+      const payload: {
+        success: boolean;
+        message?: string;
+        downloadUrl?: string;
+      } = await response.json();
+
+      if (!payload.success) {
+        setStatus(
+          payload.message
+            ? { type: "custom", message: payload.message }
+            : { type: "validationFailed" },
+        );
+        return;
+      }
+
+      setStatus(
+        payload.message
+          ? { type: "custom", message: payload.message }
+          : { type: "validationSuccess" },
+      );
+      if (payload.downloadUrl) {
+        setReportUrl(payload.downloadUrl);
+      }
+    } catch (error) {
+      console.error(error);
+      setStatus({ type: "networkError" });
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <main className="min-h-screen bg-slate-50 p-6 transition-colors duration-300 dark:bg-slate-950 md:p-10">
+      <div className="mb-8">
+        <Link
+          href="/"
+          className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-700 shadow-sm transition hover:bg-slate-100 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-200 dark:hover:bg-slate-800"
+        >
+          <span aria-hidden>←</span>
+          {common.backToHome}
+        </Link>
+      </div>
+      <section className="mx-auto flex max-w-5xl flex-col gap-8">
+        <header className="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-100 dark:bg-slate-900 dark:ring-slate-800">
+          <h1 className="text-2xl font-semibold text-slate-900 dark:text-slate-100">{hero.title}</h1>
+          <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">{hero.description}</p>
+          <label className="mt-6 flex cursor-pointer flex-col items-center gap-2 rounded-xl border-2 border-dashed border-slate-300 p-6 text-center transition hover:border-indigo-400 dark:border-slate-600 dark:bg-slate-900/40">
+            <span className="text-base font-medium text-slate-700 dark:text-slate-200">{hero.uploadLabel}</span>
+            <span className="text-sm text-slate-500 dark:text-slate-400">{hero.uploadHint}</span>
+            <input type="file" accept=".xlsx,.xlsm" className="hidden" onChange={handleFileChange} ref={fileInputRef} />
+          </label>
+        </header>
+
+        <article className="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-100 dark:bg-slate-900 dark:ring-slate-800">
+          <header className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div>
+              <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">{rulesText.heading}</h2>
+              <p className="text-sm text-slate-500 dark:text-slate-400">{rulesText.description}</p>
+            </div>
+            <div className="flex items-center gap-3">
+              <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-600 dark:bg-slate-800 dark:text-slate-200">
+                {rulesText.countLabel(rules.length)}
+              </span>
+              <button
+                type="button"
+                onClick={addRule}
+                className="inline-flex items-center rounded-lg border border-indigo-600 px-4 py-2 text-sm font-semibold text-indigo-600 transition hover:bg-indigo-50 dark:border-indigo-400 dark:text-indigo-300 dark:hover:bg-indigo-500/10"
+              >
+                {rulesText.addButton}
+              </button>
+            </div>
+          </header>
+
+          <div className="mt-6 rounded-xl border border-indigo-100 bg-indigo-50 p-4 text-sm text-indigo-900 dark:border-indigo-900 dark:bg-indigo-950/40 dark:text-indigo-200">
+            <p className="font-medium">{rulesText.tipTitle}</p>
+            <ul className="mt-2 list-disc space-y-1 pl-4">
+              {rulesText.tips.map((tip) => (
+                <li key={tip}>{tip}</li>
+              ))}
+            </ul>
+          </div>
+
+          {rules.length === 0 ? (
+            <div className="mt-6 rounded-xl border border-slate-200 bg-slate-50 p-6 text-center text-sm text-slate-600 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300">
+              <p>{rulesText.emptyState.description}</p>
+              <button
+                type="button"
+                onClick={addRule}
+                className="mt-4 inline-flex items-center rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-700"
+              >
+                {rulesText.emptyState.action}
+              </button>
+            </div>
+          ) : (
+            <div className="mt-6 space-y-6">
+              {rules.map((rule) => {
+                const fieldIsEmpty = rule.field.trim().length === 0;
+                return (
+                  <div key={rule.id} className="rounded-xl border border-slate-200 shadow-sm dark:border-slate-700 dark:bg-slate-900">
+                    <div className="flex flex-col gap-4 border-b border-slate-100 bg-slate-50 p-5 dark:border-slate-800 dark:bg-slate-950 md:flex-row md:items-end">
+                    <div className="flex-1">
+                        <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">{rulesText.field.label}</label>
+                        <input
+                          type="text"
+                          value={rule.field}
+                          onChange={(event) => updateRule(rule.id, { field: event.target.value })}
+                          className={`mt-2 w-full rounded-lg border px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:bg-slate-950 dark:text-slate-100 dark:placeholder-slate-400 ${fieldIsEmpty ? "border-rose-400 dark:border-rose-400" : "border-slate-200 dark:border-slate-700"}`}
+                          placeholder={rulesText.field.placeholder}
+                        />
+                        {fieldIsEmpty && (
+                          <p className="mt-1 text-xs text-rose-600 dark:text-rose-400">{rulesText.field.error}</p>
+                        )}
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() => removeRule(rule.id)}
+                        className="inline-flex items-center justify-center rounded-lg border border-rose-200 px-3 py-2 text-xs font-semibold text-rose-600 transition hover:bg-rose-50 dark:border-rose-400/40 dark:text-rose-300 dark:hover:bg-rose-500/10"
+                      >
+                        {rulesText.removeButton}
+                      </button>
+                    </div>
+
+                    <div className="grid gap-6 p-5 md:grid-cols-2">
+                      <div className="space-y-5">
+                        <fieldset className="grid grid-cols-2 gap-3 text-sm text-slate-700 dark:text-slate-200">
+                          <label className="flex items-center gap-2">
+                            <input
+                              type="checkbox"
+                              checked={rule.checked}
+                              onChange={(event) => updateRule(rule.id, { checked: event.target.checked })}
+                              className="h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500 dark:border-slate-600 dark:bg-slate-900 dark:text-indigo-400 dark:focus:ring-indigo-400"
+                            />
+                            {rulesText.toggles.checked}
+                          </label>
+                          <label className="flex items-center gap-2">
+                            <input
+                              type="checkbox"
+                              checked={rule.required}
+                              onChange={(event) => updateRule(rule.id, { required: event.target.checked })}
+                              className="h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500 dark:border-slate-600 dark:bg-slate-900 dark:text-indigo-400 dark:focus:ring-indigo-400"
+                            />
+                            {rulesText.toggles.required}
+                          </label>
+                        </fieldset>
+
+                        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                          <div>
+                            <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">{rulesText.length.minLabel}</label>
+                            <input
+                              type="number"
+                              value={rule.minLength ?? ""}
+                              onChange={(event) => updateRule(rule.id, { minLength: parseNumberInput(event.target.value) })}
+                              className="mt-2 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:placeholder-slate-400"
+                              placeholder={rulesText.length.placeholder}
+                            />
+                          </div>
+                          <div>
+                            <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">{rulesText.length.maxLabel}</label>
+                            <input
+                              type="number"
+                              value={rule.maxLength ?? ""}
+                              onChange={(event) => updateRule(rule.id, { maxLength: parseNumberInput(event.target.value) })}
+                              className="mt-2 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:placeholder-slate-400"
+                              placeholder={rulesText.length.placeholder}
+                            />
+                          </div>
+                        </div>
+
+                        <div>
+                          <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">{rulesText.pattern.label}</label>
+                          <input
+                            type="text"
+                            value={rule.pattern ?? ""}
+                            onChange={(event) => updateRule(rule.id, { pattern: event.target.value || undefined })}
+                            className="mt-2 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:placeholder-slate-400"
+                            placeholder={rulesText.pattern.placeholder}
+                          />
+                        </div>
+
+                        <div>
+                          <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">{rulesText.customRule.label}</label>
+                          <input
+                            type="text"
+                            value={rule.customRule ?? ""}
+                            onChange={(event) => updateRule(rule.id, { customRule: event.target.value || undefined })}
+                            className="mt-2 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:placeholder-slate-400"
+                            placeholder={rulesText.customRule.placeholder}
+                          />
+                        </div>
+                      </div>
+
+                      <div className="space-y-5">
+                        <div>
+                          <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                            {rulesText.allowed.label}
+                          </label>
+                          <select
+                            value={rule.allowedType}
+                            onChange={(event) => updateRule(rule.id, { allowedType: event.target.value as AllowedType })}
+                            className="mt-2 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100"
+                          >
+                            <option value="list">{rulesText.allowed.options.list}</option>
+                            <option value="instruction">{rulesText.allowed.options.instruction}</option>
+                          </select>
+                        </div>
+
+                        {rule.allowedType === "list" ? (
+                          <div>
+                            <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                              {rulesText.allowed.valuesLabel}
+                            </label>
+                            <textarea
+                              value={rule.allowedValues.join("\n")}
+                              onChange={(event) =>
+                                updateRule(rule.id, {
+                                  allowedValues: event.target.value
+                                    .split(/\r?\n/)
+                                    .map((value) => value.trim())
+                                    .filter((value) => value.length > 0),
+                                })
+                              }
+                              className="mt-2 h-28 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:placeholder-slate-400"
+                              placeholder={rulesText.allowed.valuesPlaceholder}
+                            />
+                            <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">{rulesText.allowed.valuesHint}</p>
+                            {rule.allowedValues.length > 0 && (
+                              <div className="mt-3 flex flex-wrap gap-2">
+                                {rule.allowedValues.map((value) => (
+                                  <span
+                                    key={`${rule.id}-${value}`}
+                                    className="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-700 dark:bg-slate-800 dark:text-slate-200"
+                                  >
+                                    {value}
+                                  </span>
+                                ))}
+                              </div>
+                            )}
+                          </div>
+                        ) : (
+                          <div>
+                            <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                              {rulesText.allowed.instructionLabel}
+                            </label>
+                            <textarea
+                              value={rule.allowedInstruction}
+                              onChange={(event) => updateRule(rule.id, { allowedInstruction: event.target.value })}
+                              className="mt-2 h-28 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:placeholder-slate-400"
+                              placeholder={rulesText.allowed.instructionPlaceholder}
+                            />
+                            <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">{rulesText.allowed.instructionHint}</p>
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </article>
+
+        <footer className="flex flex-col gap-4 rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-100 dark:bg-slate-900 dark:ring-slate-800 md:flex-row md:items-center md:justify-between">
+          <p className="text-sm text-slate-600 dark:text-slate-300">{statusMessage}</p>
+          <div className="flex flex-wrap gap-3">
+            <button
+              type="button"
+              onClick={() => resetSelection()}
+              disabled={!file || isSubmitting}
+              className="rounded-lg border border-rose-500 px-4 py-2 text-sm font-semibold text-rose-600 shadow-sm transition disabled:cursor-not-allowed disabled:opacity-50 dark:border-rose-400 dark:text-rose-300"
+            >
+              {footer.removeFile}
+            </button>
+            <button
+              type="button"
+              disabled={!file || isSubmitting || hasMissingField}
+              onClick={launchValidation}
+              className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow transition disabled:cursor-not-allowed disabled:bg-slate-300 dark:disabled:bg-slate-700"
+            >
+              {isSubmitting ? footer.validating : footer.startValidation}
+            </button>
+            {reportUrl && (
+              <a
+                href={reportUrl}
+                className="rounded-lg border border-indigo-600 px-4 py-2 text-sm font-semibold text-indigo-600 transition hover:bg-indigo-50 dark:border-indigo-400 dark:text-indigo-300 dark:hover:bg-indigo-500/10"
+              >
+                {footer.downloadReport}
+              </a>
+            )}
+          </div>
+        </footer>
+      </section>
+    </main>
+  );
+}
+

--- a/frontend/components/language-provider.tsx
+++ b/frontend/components/language-provider.tsx
@@ -29,6 +29,67 @@ const translations = {
         },
       },
     },
+    common: {
+      backToHome: "Revenir à l'accueil",
+    },
+    home: {
+      badge: "Portail DMF",
+      title: "Choisissez votre parcours",
+      description:
+        "Sélectionnez le module adapté à votre besoin : revue des fichiers ou génération d'un fichier mappé.",
+      options: {
+        review: {
+          label: "Review files",
+          title: "Valider vos fichiers DMF",
+          description:
+            "Retrouvez le processus historique pour analyser les règles, les ajuster et lancer la validation Python.",
+          action: "Accéder à la validation",
+        },
+        mapping: {
+          label: "Mapping files",
+          title: "Générer un fichier mappé",
+          description:
+            "Exécutez le script de mapping pour transformer un template Excel selon vos règles Parameters.",
+          action: "Accéder au mapping",
+        },
+      },
+    },
+    mapping: {
+      hero: {
+        badge: "Mapping Excel",
+        title: "Générez votre fichier mappé",
+        description:
+          "Utilisez le moteur Python pour appliquer vos règles Parameters et produire automatiquement un fichier mappé.",
+        uploadLabel: "Déposez ou sélectionnez votre fichier Template",
+        uploadHint: "Feuilles nécessaires : Template, Parameters et onglets de mapping associés",
+        unknownType: "Type non défini",
+      },
+      actions: {
+        selectFile: "Sélectionner un fichier",
+        changeFile: "Changer de fichier",
+        removeFile: "Retirer le fichier",
+        start: "Lancer le mapping",
+        processing: "Mapping en cours…",
+        download: "Télécharger le résultat",
+      },
+      status: {
+        idle: "Importez un fichier Excel pour démarrer le mapping.",
+        ready: (filename: string) => `Fichier prêt : ${filename}.`,
+        processing: (filename: string) => `Mapping en cours pour ${filename}…`,
+        success: (originalName: string) => `Mapping terminé. Téléchargez ${originalName}.`,
+        error: (message: string) => `Erreur lors du mapping : ${message}`,
+        genericError: "Le service de mapping a renvoyé une erreur.",
+        networkError: "Erreur réseau : impossible de contacter le service de mapping.",
+      },
+      tips: {
+        title: "Conseils d'utilisation",
+        items: [
+          "Assurez-vous que les onglets Template et Parameters sont présents et complétés.",
+          "Les feuilles mentionnées dans les règles MAPPING= doivent exister dans votre fichier Excel.",
+          "Le fichier généré porte automatiquement le suffixe _mapping pour être identifié facilement.",
+        ],
+      },
+    },
     hero: {
       title: "Validation DMF",
       description:
@@ -135,6 +196,67 @@ const translations = {
           label: "English",
           title: "Switch interface to English",
         },
+      },
+    },
+    common: {
+      backToHome: "Back to home",
+    },
+    home: {
+      badge: "DMF workspace",
+      title: "Choose your workflow",
+      description:
+        "Pick the module that matches your needs: review existing files or generate a mapped file.",
+      options: {
+        review: {
+          label: "Review files",
+          title: "Validate your DMF files",
+          description:
+            "Use the historical process to inspect the rules, adjust them and launch the Python validation.",
+          action: "Go to validation",
+        },
+        mapping: {
+          label: "Mapping files",
+          title: "Produce a mapped file",
+          description:
+            "Run the mapping script on your Excel template to generate the transformed workbook.",
+          action: "Go to mapping",
+        },
+      },
+    },
+    mapping: {
+      hero: {
+        badge: "Excel mapping",
+        title: "Generate your mapped file",
+        description:
+          "Use the Python engine to apply the Parameters rules and automatically produce a mapped workbook.",
+        uploadLabel: "Drop or select your Template file",
+        uploadHint: "Required sheets: Template, Parameters and referenced mapping tabs",
+        unknownType: "Unknown type",
+      },
+      actions: {
+        selectFile: "Select a file",
+        changeFile: "Change file",
+        removeFile: "Remove file",
+        start: "Run mapping",
+        processing: "Mapping…",
+        download: "Download result",
+      },
+      status: {
+        idle: "Import an Excel file to start the mapping process.",
+        ready: (filename: string) => `File ready: ${filename}.`,
+        processing: (filename: string) => `Mapping in progress for ${filename}…`,
+        success: (originalName: string) => `Mapping completed. Download ${originalName}.`,
+        error: (message: string) => `Mapping error: ${message}`,
+        genericError: "The mapping service returned an error.",
+        networkError: "Network error: unable to reach the mapping service.",
+      },
+      tips: {
+        title: "Tips for best results",
+        items: [
+          "Ensure the Template and Parameters sheets are present and filled in.",
+          "Sheets referenced in MAPPING= rules must exist in your workbook.",
+          "The generated file automatically receives the _mapping suffix for easier identification.",
+        ],
       },
     },
     hero: {


### PR DESCRIPTION
## Summary
- add a landing page that lets the user choose between the review and mapping workflows with contextual descriptions
- move the existing review experience under /review, extend translations, and add navigation back to the new home screen
- implement the Excel mapping workflow with a dedicated UI, Next.js API route, and Python runner reusing the existing temporary storage

## Testing
- not run (Next.js prompts for initial ESLint configuration when running `npm run lint`)

------
https://chatgpt.com/codex/tasks/task_e_68e660979754832b95932a99b89489ef